### PR TITLE
Dialog date fields

### DIFF
--- a/mvn_setup/tasks-parent/tasks-ui/src/core/DatePicker/DatePicker.tsx
+++ b/mvn_setup/tasks-parent/tasks-ui/src/core/DatePicker/DatePicker.tsx
@@ -29,7 +29,8 @@ interface DatePickerProps {
   setStartDate?: (value: React.SetStateAction<string | Date | undefined>) => void,
   dueDate: Date | string | undefined,
   setDueDate: (value: React.SetStateAction<string | Date | undefined>) => void,
-  onClose?: () => void
+  onClose?: () => void,
+  activeDate?: DateType
 }
 
 const StyledContainer = styled(Box)(({ theme }) => ({
@@ -115,12 +116,12 @@ function handleDateChangeForField(args: DateChangeProps): void {
 }
 
 const DatePicker: React.FC<DatePickerProps> = (props) => {
-  const { startDate, setStartDate, dueDate, setDueDate, onClose } = props;
+  const { startDate, setStartDate, dueDate, setDueDate, onClose, activeDate } = props;
   const doubleDate = setStartDate !== undefined;
 
   const [startDateError, setStartDateError] = React.useState<string | undefined>();
   const [dueDateError, setDueDateError] = React.useState<string | undefined>();
-  const [activeField, setActiveField] = React.useState<DateType | undefined>('due');
+  const [activeField, setActiveField] = React.useState<DateType | undefined>(activeDate || "due");
 
   function handleActiveFieldChange(field: DateType | undefined): void {
     setActiveField(field);

--- a/mvn_setup/tasks-parent/tasks-ui/src/core/TaskOps/EditTask/EditTaskDialog.tsx
+++ b/mvn_setup/tasks-parent/tasks-ui/src/core/TaskOps/EditTask/EditTaskDialog.tsx
@@ -31,17 +31,29 @@ const Right: React.FC<{}> = () => {
 
 const Header: React.FC<{}> = () => {
 
+  const { state } = TaskClient.useTaskEdit();
   const [datePickerOpen, setDatePickerOpen] = React.useState(false);
-  const [startDate, setStartDate] = React.useState<Date | string | undefined>();
-  const [dueDate, setDueDate] = React.useState<Date | string | undefined>();
+  const [startDate, setStartDate] = React.useState<Date | string | undefined>(state.task.startDate);
+  const [dueDate, setDueDate] = React.useState<Date | string | undefined>(state.task.dueDate);
+  const [activeDate, setActiveDate] = React.useState<"start" | "due" | undefined>();
+
+  const handleStartDateClick = () => {
+    setActiveDate('start');
+    setDatePickerOpen(true);
+  }
+
+  const handleDueDateClick = () => {
+    setActiveDate('due');
+    setDatePickerOpen(true);
+  }
 
   return (<>
     <Dialog open={datePickerOpen} onClose={() => setDatePickerOpen(false)}>
-      <DatePicker startDate={startDate} setStartDate={setStartDate} dueDate={dueDate} setDueDate={setDueDate} />
+      <DatePicker startDate={startDate} setStartDate={setStartDate} dueDate={dueDate} setDueDate={setDueDate} activeDate={activeDate} />
     </Dialog>
 
     <Grid container>
-      <Grid item md={6} lg={6}>
+      <Grid item md={6} lg={6} alignSelf='center'>
         <Stack spacing={2} direction='row'>
           <Fields.Status />
           <Fields.Assignee />
@@ -50,10 +62,10 @@ const Header: React.FC<{}> = () => {
         </Stack>
       </Grid>
 
-      <Grid item md={6} lg={6}>
+      <Grid item md={6} lg={6} alignSelf='center'>
         <Stack spacing={2} direction='row'>
-          <Fields.StartDate onClick={() => setDatePickerOpen(true)} />
-          <Fields.DueDate onClick={() => setDatePickerOpen(true)} dueDate='08/31/2023' />
+          <Fields.StartDate onClick={handleStartDateClick} />
+          <Fields.DueDate onClick={handleDueDateClick} />
         </Stack>
       </Grid>
     </Grid>

--- a/mvn_setup/tasks-parent/tasks-ui/src/core/TaskOps/EditTask/EditTaskFields.tsx
+++ b/mvn_setup/tasks-parent/tasks-ui/src/core/TaskOps/EditTask/EditTaskFields.tsx
@@ -1,7 +1,11 @@
 import React from 'react';
 import { FormattedMessage, useIntl } from 'react-intl';
 
-import { TextField, Typography, Stack, Box, IconButton, MenuList, MenuItem, Button, SxProps, List, ListItem, ListItemText, Avatar, AvatarGroup, Checkbox, InputAdornment } from '@mui/material';
+import {
+  TextField, Typography, Stack, Box, MenuList,
+  MenuItem, Button, SxProps, List, ListItem, ListItemText, Avatar,
+  AvatarGroup, Checkbox, InputAdornment
+} from '@mui/material';
 import DateRangeOutlinedIcon from '@mui/icons-material/DateRangeOutlined';
 import MailOutlineIcon from '@mui/icons-material/MailOutline';
 import AttachFileIcon from '@mui/icons-material/AttachFile';
@@ -110,7 +114,7 @@ const Status: React.FC<{}> = () => {
       <Popover.Delegate>
         <MenuList dense>
           {statusOptions.map(option => (
-            <MenuItem key={option}>
+            <MenuItem key={option} onClick={Popover.onClose}>
               <CircleIcon sx={{ alignItems: 'center', mr: 1, ...getStatusColorConfig(option) }} />
               <ListItemText><FormattedMessage id={'task.status.' + option} /></ListItemText>
             </MenuItem>
@@ -212,7 +216,7 @@ const Priority: React.FC<{}> = () => {
       <Popover.Delegate>
         <MenuList dense>
           {priorityOptions.map(option => (
-            <MenuItem key={option}>
+            <MenuItem key={option} onClick={Popover.onClose}>
               <EmojiFlagsIcon sx={{ alignItems: 'center', mr: 1, ...getPriorityColorConfig(option) }} />
               <ListItemText><FormattedMessage id={'task.priority.' + option} /></ListItemText>
             </MenuItem>
@@ -240,20 +244,27 @@ const NewItemNotification: React.FC<{}> = () => {
 }
 
 const StartDate: React.FC<{ onClick: () => void }> = ({ onClick }) => {
+  const { state } = TaskClient.useTaskEdit();
+  const startDate = state.task.startDate;
 
   return (
-    <Stack direction='row' alignItems='center'>
-      <Typography variant='body2'><FormattedMessage id='core.taskOps.editTask.startDate' /></Typography>
-      <IconButton onClick={onClick} color='secondary'><DateRangeOutlinedIcon /></IconButton>
-    </Stack>);
+    <Stack spacing={1} direction='row' alignItems='center'>
+      <Typography variant='body2'><FormattedMessage id='core.taskOps.workOnTask.startDate' /></Typography>
+      <Button onClick={onClick}>{startDate ? <Typography>{startDate.toLocaleDateString()}</Typography> : <DateRangeOutlinedIcon />}</Button>
+    </Stack>
+  );
 }
 
-const DueDate: React.FC<{ dueDate: string, onClick: () => void }> = ({ dueDate, onClick }) => {
+const DueDate: React.FC<{ onClick: () => void }> = ({ onClick }) => {
+  const { state } = TaskClient.useTaskEdit();
+  const dueDate = state.task.dueDate;
+
   return (
-    <Stack spacing={1} direction='row' onClick={onClick} alignItems='center'>
-      <Typography variant='body2'><FormattedMessage id='core.taskOps.editTask.dueDate' /></Typography>
-      <Typography>{dueDate}</Typography>
-    </Stack>)
+    <Stack spacing={1} direction='row' alignItems='center'>
+      <Typography variant='body2'><FormattedMessage id='core.taskOps.workOnTask.dueDate' /></Typography>
+      <Button onClick={onClick}>{dueDate ? <Typography>{dueDate.toLocaleDateString()}</Typography> : <DateRangeOutlinedIcon />}</Button>
+    </Stack>
+  );
 }
 
 


### PR DESCRIPTION
- Fixed startDate and dueDate fields in dialogs to display mock data instead of hard-coding them
- Calendar icon is displayed if a date is undefined
- Dates/calendar icons are inside of buttons to indicate they are clickable
- Clicking the start date opens the Date Picker with the start date field focused and vice versa

<img src='https://github.com/digiexpress-io/digiexpress-parent/assets/80248680/9c3ed99d-8b74-463e-9a51-b71b269d65c5' width='400px' />

[Demo video](https://drive.google.com/file/d/1fz4O-1Dvbr6N0nBLuNOZU1RVpCfbpHo6/view?usp=sharing)


