### PR TITLE
ui - popover menu for the roles in adminboard

### DIFF
--- a/mvn_setup/tasks-parent/tasks-ui/src/core/SearchField/index.tsx
+++ b/mvn_setup/tasks-parent/tasks-ui/src/core/SearchField/index.tsx
@@ -1,0 +1,22 @@
+import { InputAdornment, TextField } from "@mui/material";
+import SearchIcon from '@mui/icons-material/Search';
+
+const SearchField: React.FC<{ onChange: (value: string) => void }> = ({ onChange }) => {
+  return (
+    <TextField
+      InputProps={{
+        startAdornment: (
+          <InputAdornment position="start">
+            <SearchIcon color='primary' />
+          </InputAdornment>
+        ),
+      }}
+      fullWidth
+      variant='standard'
+      placeholder='Search'
+      onChange={(e) => onChange(e.target.value)}
+    />
+  );
+}
+
+export default SearchField;

--- a/mvn_setup/tasks-parent/tasks-ui/src/core/TaskAssignees/index.tsx
+++ b/mvn_setup/tasks-parent/tasks-ui/src/core/TaskAssignees/index.tsx
@@ -1,14 +1,13 @@
 import React from 'react';
-import { AvatarGroup, Box, ListItemText, InputAdornment, ListItem, Checkbox, Button, Avatar, List, TextField, ButtonProps, styled, ListItemTextProps } from '@mui/material';
-import SearchIcon from '@mui/icons-material/Search';
+import { AvatarGroup, Box, ListItemText, ListItem, AvatarProps, Checkbox, Button, Avatar, List, ButtonProps, styled, ListItemTextProps } from '@mui/material';
 import PersonAddIcon from '@mui/icons-material/PersonAdd';
 
 import Client from '@taskclient';
 
-import { TaskDescriptor } from 'taskclient/tasks-ctx-types';
+import { AvatarCode, TaskDescriptor } from 'taskclient/tasks-ctx-types';
 import { usePopover } from 'core/TaskTable/CellPopover';
 import { useAssignees } from 'taskclient/hooks';
-
+import SearchField from 'core/SearchField';
 
 const StyledButton = styled(Button)<ButtonProps>(() => ({
   variant: 'text',
@@ -18,42 +17,27 @@ const StyledButton = styled(Button)<ButtonProps>(() => ({
   },
 }));
 
+const StyledAvatar = styled(Avatar)<AvatarProps & {bgcolor: string | undefined}>(({ bgcolor }) => ({
+  backgroundColor: bgcolor,
+  width: 24,
+  height: 24,
+  fontSize: 10
+}));
+
 const StyledListItemText = styled(ListItemText)<ListItemTextProps>(({theme}) => ({
   marginLeft: theme.spacing(1)
 }));
-
-const SearchField: React.FC<{ onChange: (value: string) => void }> = ({ onChange }) => {
-  return (
-    <TextField
-      InputProps={{
-        startAdornment: (
-          <InputAdornment position="start">
-            <SearchIcon color='primary' />
-          </InputAdornment>
-        ),
-      }}
-      fullWidth
-      variant='standard'
-      placeholder='Search'
-      onChange={(e) => onChange(e.target.value)}
-    />
-  );
-}
 
 const UserAvatar: React.FC<{ children?: Client.AvatarCode, onClick?: (event: React.MouseEvent<HTMLElement>) => void }> = ({ children, onClick }) => {
   const { state } = Client.useTasks();
   const bgcolor: string | undefined = children ? state.pallette.owners[children.value] : undefined;
 
-  return (<Avatar onClick={onClick}
-    sx={{
-      bgcolor,
-      width: 24,
-      height: 24,
-      fontSize: 10,
-    }}>
+  const avatar = children ? children.twoletters : <PersonAddIcon sx={{ fontSize: 15 }} />;
 
-    {children ? children.twoletters : <PersonAddIcon sx={{ fontSize: 15 }} />}
-  </Avatar>
+  return (
+    <StyledAvatar onClick={onClick} bgcolor={bgcolor}>
+      {avatar}
+    </StyledAvatar>
   );
 }
   
@@ -61,16 +45,17 @@ const TaskAssignees: React.FC<{ task: TaskDescriptor }> = ({ task }) => {
   const Popover = usePopover();
   const { setSearchString, searchResults } = useAssignees(task);
 
+  const taskAssigneeAvatars = task.assigneesAvatars.length ? 
+    <AvatarGroup spacing='medium' onClick={Popover.onClick}>
+      {task.assigneesAvatars.map((assignee: AvatarCode) => (<UserAvatar key={assignee.value}>{assignee}</UserAvatar>))}
+    </AvatarGroup> : 
+    <UserAvatar onClick={Popover.onClick}/>
+
   return (
     <Box>
       <StyledButton>
-        {task.assigneesAvatars.length ? (
-          <AvatarGroup spacing='medium' onClick={Popover.onClick}>
-            {task.assigneesAvatars.map(assignee => (<UserAvatar>{assignee}</UserAvatar>))}
-          </AvatarGroup>) : <UserAvatar onClick={Popover.onClick}/>
-        }
+        {taskAssigneeAvatars}
       </StyledButton>
-
       <Popover.Delegate>
         <SearchField onChange={setSearchString} />
         <List dense>

--- a/mvn_setup/tasks-parent/tasks-ui/src/core/TaskAssignees/index.tsx
+++ b/mvn_setup/tasks-parent/tasks-ui/src/core/TaskAssignees/index.tsx
@@ -4,9 +4,7 @@ import PersonAddIcon from '@mui/icons-material/PersonAdd';
 
 import Client from '@taskclient';
 
-import { AvatarCode, TaskDescriptor } from 'taskclient/tasks-ctx-types';
 import { usePopover } from 'core/TaskTable/CellPopover';
-import { useAssignees } from 'taskclient/hooks';
 import SearchField from 'core/SearchField';
 
 const StyledButton = styled(Button)<ButtonProps>(() => ({
@@ -41,13 +39,13 @@ const UserAvatar: React.FC<{ children?: Client.AvatarCode, onClick?: (event: Rea
   );
 }
   
-const TaskAssignees: React.FC<{ task: TaskDescriptor }> = ({ task }) => {
+const TaskAssignees: React.FC<{ task: Client.TaskDescriptor }> = ({ task }) => {
   const Popover = usePopover();
-  const { setSearchString, searchResults } = useAssignees(task);
+  const { setSearchString, searchResults } = Client.useAssignees(task);
 
   const taskAssigneeAvatars = task.assigneesAvatars.length ? 
     <AvatarGroup spacing='medium' onClick={Popover.onClick}>
-      {task.assigneesAvatars.map((assignee: AvatarCode) => (<UserAvatar key={assignee.value}>{assignee}</UserAvatar>))}
+      {task.assigneesAvatars.map((assignee: Client.AvatarCode) => (<UserAvatar key={assignee.value}>{assignee}</UserAvatar>))}
     </AvatarGroup> : 
     <UserAvatar onClick={Popover.onClick}/>
 

--- a/mvn_setup/tasks-parent/tasks-ui/src/core/TaskRoles/index.tsx
+++ b/mvn_setup/tasks-parent/tasks-ui/src/core/TaskRoles/index.tsx
@@ -1,0 +1,78 @@
+import React from 'react';
+import { AvatarGroup, Box, ListItemText,AvatarProps, ListItem, Checkbox, Button, Avatar, List, ButtonProps, styled } from '@mui/material';
+import AdminPanelSettingsIcon from '@mui/icons-material/AdminPanelSettings';
+
+import Client from '@taskclient';
+
+import { AvatarCode, TaskDescriptor } from 'taskclient/tasks-ctx-types';
+import { usePopover } from 'core/TaskTable/CellPopover';
+import { useRoles } from 'taskclient/hooks';
+import SearchField from 'core/SearchField';
+
+const StyledButton = styled(Button)<ButtonProps>(() => ({
+  variant: 'text',
+  color: 'inherit',
+  "&.MuiButtonBase-root": {
+    minWidth: "unset",
+  },
+}));
+
+const StyledAvatar = styled(Avatar)<AvatarProps & {bgcolor: string | undefined}>(({ bgcolor, theme }) => ({
+  marginRight: theme.spacing(1),
+  backgroundColor: bgcolor,
+  width: 24,
+  height: 24,
+  fontSize: 10
+}));
+
+const StyledAdminPanelSettingsIcon = styled(AdminPanelSettingsIcon)(() => ({
+  fontSize: 15
+}));
+
+const RoleAvatar: React.FC<{ children?: Client.AvatarCode, onClick?: (event: React.MouseEvent<HTMLElement>) => void }> = ({ children, onClick }) => {
+  const { state } = Client.useTasks();
+  const bgcolor: string | undefined = children ? state.pallette.roles[children.value] : undefined;
+
+  const avatar = children ? children.twoletters : <StyledAdminPanelSettingsIcon />;
+
+  return (
+    <StyledAvatar onClick={onClick} bgcolor={bgcolor}>
+      {avatar}
+    </StyledAvatar>
+  );
+}
+  
+const TaskRoles: React.FC<{ task: TaskDescriptor }> = ({ task }) => {
+  const Popover = usePopover();
+  const { setSearchString, searchResults } = useRoles(task);
+
+  const taskRoleAvatars = task.rolesAvatars.length ? 
+    <AvatarGroup spacing='medium' onClick={Popover.onClick}>
+      {task.rolesAvatars.map((role: AvatarCode) => (<RoleAvatar key={role.value}>{role}</RoleAvatar>))}
+    </AvatarGroup> : 
+    <RoleAvatar onClick={Popover.onClick}/>;
+
+  return (
+    <Box>
+      <StyledButton>
+        {taskRoleAvatars}
+      </StyledButton>
+      <Popover.Delegate>
+        <SearchField onChange={setSearchString} />
+        <List dense>
+          {
+            searchResults.map(({ avatar, role, checked }) => (
+              <ListItem key={role.roleId}>
+                <Checkbox checked={checked} />
+                <RoleAvatar>{avatar}</RoleAvatar>
+                <ListItemText>{role.displayName}</ListItemText>
+              </ListItem>
+            ))
+          }
+        </List>
+      </Popover.Delegate>
+    </Box>
+  );
+}
+
+export default TaskRoles;

--- a/mvn_setup/tasks-parent/tasks-ui/src/core/TaskRoles/index.tsx
+++ b/mvn_setup/tasks-parent/tasks-ui/src/core/TaskRoles/index.tsx
@@ -1,12 +1,10 @@
 import React from 'react';
-import { AvatarGroup, Box, ListItemText,AvatarProps, ListItem, Checkbox, Button, Avatar, List, ButtonProps, styled } from '@mui/material';
+import { AvatarGroup, Box, ListItemText,AvatarProps, ListItem, Checkbox, Button, Avatar, ListItemTextProps, List, ButtonProps, styled } from '@mui/material';
 import AdminPanelSettingsIcon from '@mui/icons-material/AdminPanelSettings';
 
 import Client from '@taskclient';
 
-import { AvatarCode, TaskDescriptor } from 'taskclient/tasks-ctx-types';
 import { usePopover } from 'core/TaskTable/CellPopover';
-import { useRoles } from 'taskclient/hooks';
 import SearchField from 'core/SearchField';
 
 const StyledButton = styled(Button)<ButtonProps>(() => ({
@@ -18,7 +16,6 @@ const StyledButton = styled(Button)<ButtonProps>(() => ({
 }));
 
 const StyledAvatar = styled(Avatar)<AvatarProps & {bgcolor: string | undefined}>(({ bgcolor, theme }) => ({
-  marginRight: theme.spacing(1),
   backgroundColor: bgcolor,
   width: 24,
   height: 24,
@@ -27,6 +24,10 @@ const StyledAvatar = styled(Avatar)<AvatarProps & {bgcolor: string | undefined}>
 
 const StyledAdminPanelSettingsIcon = styled(AdminPanelSettingsIcon)(() => ({
   fontSize: 15
+}));
+
+const StyledListItemText = styled(ListItemText)<ListItemTextProps>(({theme}) => ({
+  marginLeft: theme.spacing(1)
 }));
 
 const RoleAvatar: React.FC<{ children?: Client.AvatarCode, onClick?: (event: React.MouseEvent<HTMLElement>) => void }> = ({ children, onClick }) => {
@@ -42,13 +43,13 @@ const RoleAvatar: React.FC<{ children?: Client.AvatarCode, onClick?: (event: Rea
   );
 }
   
-const TaskRoles: React.FC<{ task: TaskDescriptor }> = ({ task }) => {
+const TaskRoles: React.FC<{ task: Client.TaskDescriptor }> = ({ task }) => {
   const Popover = usePopover();
-  const { setSearchString, searchResults } = useRoles(task);
+  const { setSearchString, searchResults } = Client.useRoles(task);
 
   const taskRoleAvatars = task.rolesAvatars.length ? 
     <AvatarGroup spacing='medium' onClick={Popover.onClick}>
-      {task.rolesAvatars.map((role: AvatarCode) => (<RoleAvatar key={role.value}>{role}</RoleAvatar>))}
+      {task.rolesAvatars.map((role: Client.AvatarCode) => (<RoleAvatar key={role.value}>{role}</RoleAvatar>))}
     </AvatarGroup> : 
     <RoleAvatar onClick={Popover.onClick}/>;
 
@@ -65,7 +66,7 @@ const TaskRoles: React.FC<{ task: TaskDescriptor }> = ({ task }) => {
               <ListItem key={role.roleId}>
                 <Checkbox checked={checked} />
                 <RoleAvatar>{avatar}</RoleAvatar>
-                <ListItemText>{role.displayName}</ListItemText>
+                <StyledListItemText>{role.displayName}</StyledListItemText>
               </ListItem>
             ))
           }

--- a/mvn_setup/tasks-parent/tasks-ui/src/core/TaskTable/CellRoles.tsx
+++ b/mvn_setup/tasks-parent/tasks-ui/src/core/TaskTable/CellRoles.tsx
@@ -3,12 +3,12 @@ import React from 'react';
 import { StyledTableCell } from './StyledTable';
 import TaskRoles from 'core/TaskRoles';
 
-import client from '@taskclient';
+import Client from '@taskclient';
 
 const FormattedCell: React.FC<{
   rowId: number,
-  row: client.TaskDescriptor,
-  def: client.Group
+  row: Client.TaskDescriptor,
+  def: Client.Group
 }> = ({ row }) => {
 
   return (

--- a/mvn_setup/tasks-parent/tasks-ui/src/core/TaskTable/CellRoles.tsx
+++ b/mvn_setup/tasks-parent/tasks-ui/src/core/TaskTable/CellRoles.tsx
@@ -1,45 +1,18 @@
 import React from 'react';
-import { Box, Avatar, SxProps } from '@mui/material';
+
+import { StyledTableCell } from './StyledTable';
+import TaskRoles from 'core/TaskRoles';
 
 import client from '@taskclient';
-import TaskCell from './TaskCell';
-import { usePopover } from './CellPopover';
-import { CellProps } from './task-table-types';
-import { StyledTableCell } from './StyledTable';
-
-
-function getRoles(def: client.Group): SxProps | undefined {
-  if (!def.color) {
-    return undefined;
-  }
-
-  return undefined;
-}
-
-
-const Roles: React.FC<CellProps> = ({ row, def }) => {
-  const { state } = client.useTasks();
-
-  const avatars = row.rolesAvatars.map((entry, index) => <Avatar key={index} sx={{
-    mr: 0.5,
-    bgcolor: state.pallette.roles[entry.value],
-    width: 24,
-    height: 24,
-    fontSize: 10
-  }}>{entry.twoletters}</Avatar>);
-
-  return (<TaskCell id={row.id + "/Roles"} name={<Box flexDirection="row" display="flex">{avatars}</Box>} />);
-}
-
 
 const FormattedCell: React.FC<{
   rowId: number,
   row: client.TaskDescriptor,
   def: client.Group
-}> = ({ row, def }) => {
+}> = ({ row }) => {
 
   return (
-    <StyledTableCell sx={getRoles(def)}><Roles row={row} def={def}/></StyledTableCell>
+    <StyledTableCell><TaskRoles task={row} /></StyledTableCell>
   );
 }
 

--- a/mvn_setup/tasks-parent/tasks-ui/src/taskclient/client-types.ts
+++ b/mvn_setup/tasks-parent/tasks-ui/src/taskclient/client-types.ts
@@ -16,14 +16,22 @@ export interface ProgramMessage {
 
 export type UserId = string;
 
+export type RoleId = string;
+
 export interface Org {
   users: Record<UserId, User>;
-  roles: string[];
+  roles: Record<RoleId, Role>;
+}
+
+export interface Role {
+  roleId: RoleId;
+  avatar: string;
+  displayName: string;
 }
 
 export interface User {
   userId: UserId;
-  userRoles: string[];
+  userRoles: RoleId[];
   displayName: string;
   avatar: string;
   activity: UserActivity[];

--- a/mvn_setup/tasks-parent/tasks-ui/src/taskclient/client.ts
+++ b/mvn_setup/tasks-parent/tasks-ui/src/taskclient/client.ts
@@ -1,16 +1,35 @@
-import { Client, Store, Org, User } from './client-types';
+import { Client, Store, Org, User, Role } from './client-types';
 import type { TaskId, Task, TaskPagination, TaskStore } from './task-types';
 import type { Profile, ProfileStore } from './profile-types';
 import { } from './client-store';
 
-
-const mockRoles: string[] = [
-  "admin-role",
-  "water-department",
-  "education-department",
-  "elderly-care-department",
-  "sanitization-department"
-];
+const mockRoles: Record<string, Role> = {
+  "admin-role": {
+    roleId: "admin-role",
+    avatar: "AR",
+    displayName: "Admin Role"
+  },
+  "water-department": {
+    roleId: "water-department",
+    avatar: "WD",
+    displayName: "Water Department"
+  },
+  "education-department": {
+    roleId: "education-department",
+    avatar: "ED",
+    displayName: "Education Department"
+  },
+  "elderly-care-department": {
+    roleId: "elderly-care-department",
+    avatar: "EC",
+    displayName: "Elderly Care Department"
+  },
+  "sanitization-department": {
+    roleId: "sanitization-department",
+    avatar: "SD",
+    displayName: "Sanitization Department"
+  }
+};
 
 const mockUsers: User[] = [
   {

--- a/mvn_setup/tasks-parent/tasks-ui/src/taskclient/hooks.tsx
+++ b/mvn_setup/tasks-parent/tasks-ui/src/taskclient/hooks.tsx
@@ -13,7 +13,6 @@ import { TaskEditContext } from './task-edit-ctx'
 import { ScreenContextType } from './screen-ctx-types';
 import { ScreenContext } from './screen-ctx';
 
-
 const isDocumentSaved = (entity: Document, ide: ComposerContextType): boolean => {
   const unsaved = Object.values(ide.session.pages).filter(p => !p.saved).filter(p => p.origin.id === entity.id);
   return unsaved.length === 0
@@ -62,32 +61,46 @@ export const useTaskEdit = () => {
   const result: TaskEditContextType = React.useContext(TaskEditContext);
   return result;
 }
+
 export const useTasks = () => {
   const result: TasksContextType = React.useContext(TasksContext);
   return result;
 }
+
 export const useAssignees = (row: TaskDescriptor) => {
   const org = useOrg();
   const [searchString, setSearchString] = React.useState<string>('');
   const searchResults = React.useMemo(() => org.state.findUsers(searchString, row.assignees), [row, searchString, org]);
   return { searchString, setSearchString, searchResults };
 }
+
+export const useRoles = (row: TaskDescriptor) => {
+  const org = useOrg();
+  const [searchString, setSearchString] = React.useState<string>('');
+  const searchResults = React.useMemo(() => org.state.findRoles(searchString, row.roles), [row, searchString, org]);
+  return { searchString, setSearchString, searchResults };
+}
+
 export const useOrg = () => {
   const result: OrgContextType = React.useContext(OrgContext);
   return result;
 }
+
 export const useBackend = () => {
   const result: ClientContextType = React.useContext(ClientContext);
   return result;
 }
+
 export const useSite = () => {
   const result: ComposerContextType = React.useContext(ComposerContext);
   return result.session.profile;
 }
+
 export const useUnsaved = (entity: Document) => {
   const ide: ComposerContextType = React.useContext(ComposerContext);
   return !isDocumentSaved(entity, ide);
 }
+
 export const useComposer = () => {
   const client: ClientContextType = React.useContext(ClientContext);
   const result: ComposerContextType = React.useContext(ComposerContext);
@@ -100,10 +113,12 @@ export const useComposer = () => {
     client
   };
 }
+
 export const useSession = () => {
   const result: ComposerContextType = React.useContext(ComposerContext);
   return result.session;
 }
+
 export const useNav = () => {
   const layout: Burger.TabsContextType = Burger.useTabs();
   const findTab = (article: Document): Tab | undefined => {

--- a/mvn_setup/tasks-parent/tasks-ui/src/taskclient/index.ts
+++ b/mvn_setup/tasks-parent/tasks-ui/src/taskclient/index.ts
@@ -3,7 +3,6 @@ import { DefaultStore as DefaultStoreAs } from './client-store';
 
 import { TablePagination, TablePagination as TablePaginationAs } from './table-pagination';
 
-
 import {
   ClientError, Client, StoreConfig, Store,
   ProgramMessage, Org, User
@@ -69,7 +68,6 @@ import * as screenCtx from './screen-ctx';
 import { ScreenState } from './screen-ctx-types';
 
 import * as Hooks from './hooks';
-
 
 declare namespace TaskClient {
   export type { TablePagination };
@@ -141,6 +139,7 @@ namespace TaskClient {
   export const useTasks = Hooks.useTasks;
   export const useOrg = Hooks.useOrg;
   export const useAssignees = Hooks.useAssignees;
+  export const useRoles = Hooks.useRoles;
   export const useTaskEdit = Hooks.useTaskEdit;
   export const useSite = Hooks.useSite;
   export const useUnsaved = Hooks.useUnsaved;

--- a/mvn_setup/tasks-parent/tasks-ui/src/taskclient/org-ctx-impl.ts
+++ b/mvn_setup/tasks-parent/tasks-ui/src/taskclient/org-ctx-impl.ts
@@ -1,12 +1,10 @@
 import {
-  UserId, User, Org
+  UserId, User, Org, RoleId
 } from './client-types';
 
 import {
-  OrgState, UserSearchResult
+  OrgState, RoleSearchResult, UserSearchResult
 } from './org-ctx-types';
-
-
 
 interface ExtendedInit {
   org: Org; 
@@ -43,6 +41,21 @@ class OrgMutatorBuilderImpl implements OrgState {
       checked: checkedUsers.includes(user.userId),
       avatar: { twoletters: user.avatar, value: user.userId },
       user
+    }));
+  }
+
+  findRoles(searchFor: string, checkedRoles: RoleId[]): RoleSearchResult[] {
+    const criteria = searchFor.toLowerCase();
+    const target = Object.values(this._org.roles);
+    
+    const result = criteria ?
+      target.filter(entry => entry.displayName.toLowerCase().includes(criteria)) :
+      target;
+
+    return result.map(role => ({
+      checked: checkedRoles.includes(role.roleId),
+      avatar: { twoletters: role.avatar, value: role.roleId },
+      role
     }));
   }
   

--- a/mvn_setup/tasks-parent/tasks-ui/src/taskclient/org-ctx-types.ts
+++ b/mvn_setup/tasks-parent/tasks-ui/src/taskclient/org-ctx-types.ts
@@ -1,4 +1,4 @@
-import { Org, User, UserId } from './client-types'; 
+import { Org, User, UserId, Role, RoleId } from './client-types'; 
 
 export interface OrgContextType {
   setState: OrgDispatch;
@@ -15,6 +15,12 @@ export interface UserSearchResult {
   user: User
 }
 
+export interface RoleSearchResult {
+  checked: boolean,
+  avatar: { twoletters: string, value: RoleId },
+  role: Role
+}
+
 export interface OrgState { 
   org: Org; 
   iam: User; 
@@ -23,4 +29,5 @@ export interface OrgState {
   withIam(value: User): OrgState;
   
   findUsers(searchFor: string, checkedUsers: UserId[]): UserSearchResult[];
+  findRoles(searchFor: string, checkedRoles: RoleId[]): RoleSearchResult[];
 }

--- a/mvn_setup/tasks-parent/tasks-ui/src/taskclient/org-ctx.tsx
+++ b/mvn_setup/tasks-parent/tasks-ui/src/taskclient/org-ctx.tsx
@@ -6,11 +6,9 @@ import { Client } from './client-types';
 
 const OrgContext = React.createContext<OrgContextType>({} as OrgContextType);
 
-
-
 const init: OrgState = new OrgMutatorBuilderImpl({
   iam: { displayName: "" , userId: "", userRoles: [], avatar: '', activity: []},
-  org: { roles: [], users: {} }
+  org: { roles: {}, users: {} }
 });
 
 const OrgProvider: React.FC<{ children: React.ReactNode, backend: Client }> = ({ children, backend }) => {

--- a/mvn_setup/tasks-parent/tasks-ui/src/taskclient/profile-types.ts
+++ b/mvn_setup/tasks-parent/tasks-ui/src/taskclient/profile-types.ts
@@ -1,9 +1,9 @@
-
+import { RoleId } from "./client-types";
 
 export interface Profile {
   name: string,
   userId: string,
-  roles: string[],
+  roles: RoleId[],
   today: Date,
   commit?: string,
   contentType: "OK" | "NOT_CREATED" | "EMPTY" | "ERRORS" | "NO_CONNECTION" | "BACKEND_NOT_FOUND",

--- a/mvn_setup/tasks-parent/tasks-ui/src/taskclient/profile-types.ts
+++ b/mvn_setup/tasks-parent/tasks-ui/src/taskclient/profile-types.ts
@@ -1,8 +1,8 @@
-import { RoleId } from "./client-types";
+import { RoleId, UserId } from "./client-types";
 
 export interface Profile {
   name: string,
-  userId: string,
+  userId: UserId,
   roles: RoleId[],
   today: Date,
   commit?: string,

--- a/mvn_setup/tasks-parent/tasks-ui/src/taskclient/tasks-ctx-impl.ts
+++ b/mvn_setup/tasks-parent/tasks-ui/src/taskclient/tasks-ctx-impl.ts
@@ -1,4 +1,4 @@
-import { parseISO, isAfter, isEqual, subDays, differenceInCalendarDays } from 'date-fns';
+import { parseISO, isAfter, isEqual, differenceInCalendarDays } from 'date-fns';
 
 import { Task, TaskExtension, TaskPriority, TaskStatus } from './task-types';
 import {


### PR DESCRIPTION
Changed the CellRoles.tsx Inside the TaskTable so that now it is rendering a new made component called: "TaskRoles".
This component has been done similar to the "TaskAssignees" component.
I made some improvements in terms of reduced complexity in both TaskRoles and TaskAssignees.
I also changed some styling so that sx and styled are not mixed here.
New type was created for the Role, and also a new hook called useRoles.
I then made sure to fix all the role occasions inside the taskclient folder, since now the types are not the same for them.
Avatar for the row with no roles is now displaying a different icon.
Searchfield is used in two different folders, so I made a component for it and exported it from there.

**Screenshots**

![image](https://github.com/digiexpress-io/digiexpress-parent/assets/37162148/d5000840-c6ae-4c60-b9dc-c7a37b3f86db)

![image](https://github.com/digiexpress-io/digiexpress-parent/assets/37162148/830a8253-ef88-4e73-a298-490ac3981957)

![image](https://github.com/digiexpress-io/digiexpress-parent/assets/37162148/cb159d85-5996-4dca-b93b-4f6d33c19154)
