### PR TITLE
Priority popover menu in tasktable

### DIFF
--- a/mvn_setup/tasks-parent/tasks-ui/src/core/TaskEdit/TaskEditFields.tsx
+++ b/mvn_setup/tasks-parent/tasks-ui/src/core/TaskEdit/TaskEditFields.tsx
@@ -10,18 +10,18 @@ import MailOutlineIcon from '@mui/icons-material/MailOutline';
 import AttachFileIcon from '@mui/icons-material/AttachFile';
 import CircleNotificationsOutlinedIcon from '@mui/icons-material/CircleNotificationsOutlined';
 import CircleIcon from '@mui/icons-material/Circle';
-import EmojiFlagsIcon from '@mui/icons-material/EmojiFlags';
 import CloseIcon from '@mui/icons-material/Close';
 
-import TaskClient from '@taskclient';
+import Client from '@taskclient';
 
 import ChecklistDelegate from 'core/Checklist';
 import { usePopover } from 'core/TaskTable/CellPopover';
 import TaskAssignees from 'core/TaskAssignees';
+import TaskPriorities from 'core/TaskPriorities';
 
 
 const Title: React.FC<{}> = () => {
-  const { state } = TaskClient.useTaskEdit();
+  const { state } = Client.useTaskEdit();
   const intl = useIntl();
 
   return (<TextField
@@ -33,7 +33,7 @@ const Title: React.FC<{}> = () => {
 }
 
 const Description: React.FC<{}> = () => {
-  const { state } = TaskClient.useTaskEdit();
+  const { state } = Client.useTaskEdit();
   const intl = useIntl();
 
   return (<TextField placeholder={intl.formatMessage({ id: 'core.taskEdit.taskDescription' })} multiline rows={4} maxRows={6} fullWidth
@@ -41,7 +41,7 @@ const Description: React.FC<{}> = () => {
 }
 
 const Checklist: React.FC<{}> = () => {
-  const { state } = TaskClient.useTaskEdit();
+  const { state } = Client.useTaskEdit();
 
   console.log(state);
 
@@ -52,8 +52,8 @@ const Checklist: React.FC<{}> = () => {
   )
 }
 
-const getStatusColorConfig = (status: TaskClient.TaskStatus): SxProps => {
-  const statusColors = TaskClient.StatusPallette;
+const getStatusColorConfig = (status: Client.TaskStatus): SxProps => {
+  const statusColors = Client.StatusPallette;
   switch (status) {
     case 'COMPLETED':
       return { color: statusColors.COMPLETED, ':hover': { color: statusColors.COMPLETED } };
@@ -66,23 +66,11 @@ const getStatusColorConfig = (status: TaskClient.TaskStatus): SxProps => {
   }
 }
 
-const getPriorityColorConfig = (priority: TaskClient.TaskPriority): SxProps => {
-  const priorityColors = TaskClient.PriorityPalette;
-  switch (priority) {
-    case 'LOW':
-      return { color: priorityColors.LOW, ':hover': { color: priorityColors.LOW } };
-    case 'MEDIUM':
-      return { color: priorityColors.MEDIUM, ':hover': { color: priorityColors.MEDIUM } };
-    case 'HIGH':
-      return { color: priorityColors.HIGH, ':hover': { color: priorityColors.HIGH } };
-  }
-}
-
 const Status: React.FC<{}> = () => {
-  const { state } = TaskClient.useTaskEdit();
+  const { state } = Client.useTaskEdit();
   const status = state.task.status;
   const Popover = usePopover();
-  const statusOptions: TaskClient.TaskStatus[] = ['CREATED', 'IN_PROGRESS', 'COMPLETED', 'REJECTED'];
+  const statusOptions: Client.TaskStatus[] = ['CREATED', 'IN_PROGRESS', 'COMPLETED', 'REJECTED'];
 
   return (
     <Box>
@@ -105,7 +93,7 @@ const Status: React.FC<{}> = () => {
 }
 
 const Assignee: React.FC<{}> = () => {
-  const { state } = TaskClient.useTaskEdit();
+  const { state } = Client.useTaskEdit();
 
   return (
     <TaskAssignees task={state.task}/>
@@ -113,28 +101,10 @@ const Assignee: React.FC<{}> = () => {
 }
 
 const Priority: React.FC<{}> = () => {
-  const { state } = TaskClient.useTaskEdit();
-  const priority = state.task.priority;
-  const Popover = usePopover();
-  const priorityOptions: TaskClient.TaskPriority[] = ['LOW', 'HIGH', 'MEDIUM'];
+  const { state } = Client.useTaskEdit();
 
   return (
-    <Box>
-      <Button variant='text' color='inherit' onClick={Popover.onClick} sx={{ textTransform: 'none' }}>
-        <EmojiFlagsIcon sx={{ mr: 1, ...getPriorityColorConfig(priority) }} />
-        <Typography><FormattedMessage id={'task.priority.' + priority} /></Typography>
-      </Button>
-      <Popover.Delegate>
-        <MenuList dense>
-          {priorityOptions.map(option => (
-            <MenuItem key={option} onClick={Popover.onClose}>
-              <EmojiFlagsIcon sx={{ alignItems: 'center', mr: 1, ...getPriorityColorConfig(option) }} />
-              <ListItemText><FormattedMessage id={'task.priority.' + option} /></ListItemText>
-            </MenuItem>
-          ))}
-        </MenuList>
-      </Popover.Delegate>
-    </Box>
+    <TaskPriorities task={state.task} showPriorityText/>
   )
 }
 
@@ -155,7 +125,7 @@ const NewItemNotification: React.FC<{}> = () => {
 }
 
 const StartDate: React.FC<{ onClick: () => void }> = ({ onClick }) => {
-  const { state } = TaskClient.useTaskEdit();
+  const { state } = Client.useTaskEdit();
   const startDate = state.task.startDate;
 
   return (
@@ -167,7 +137,7 @@ const StartDate: React.FC<{ onClick: () => void }> = ({ onClick }) => {
 }
 
 const DueDate: React.FC<{ onClick: () => void }> = ({ onClick }) => {
-  const { state } = TaskClient.useTaskEdit();
+  const { state } = Client.useTaskEdit();
   const dueDate = state.task.dueDate;
 
   return (

--- a/mvn_setup/tasks-parent/tasks-ui/src/core/TaskEdit/TaskEditFields.tsx
+++ b/mvn_setup/tasks-parent/tasks-ui/src/core/TaskEdit/TaskEditFields.tsx
@@ -17,7 +17,7 @@ import Client from '@taskclient';
 import ChecklistDelegate from 'core/Checklist';
 import { usePopover } from 'core/TaskTable/CellPopover';
 import TaskAssignees from 'core/TaskAssignees';
-import TaskPriorities from 'core/TaskPriorities';
+import TaskPriority from 'core/TaskPriority';
 
 
 const Title: React.FC<{}> = () => {
@@ -104,7 +104,7 @@ const Priority: React.FC<{}> = () => {
   const { state } = Client.useTaskEdit();
 
   return (
-    <TaskPriorities task={state.task} showPriorityText/>
+    <TaskPriority task={state.task} priorityTextEnabled/>
   )
 }
 

--- a/mvn_setup/tasks-parent/tasks-ui/src/core/TaskPriorities/index.tsx
+++ b/mvn_setup/tasks-parent/tasks-ui/src/core/TaskPriorities/index.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { SxProps, MenuList, MenuItem, ListItemText, Box, Button, Typography } from '@mui/material';
+import EmojiFlagsIcon from '@mui/icons-material/EmojiFlags';
+import { FormattedMessage } from 'react-intl';
+
+import Client from '@taskclient';
+import { usePopover } from 'core/TaskTable/CellPopover';
+
+const priorityColors = Client.PriorityPalette;
+const priorityOptions: Client.TaskPriority[] = ['LOW', 'HIGH', 'MEDIUM'];
+
+function getPrioritySx(priority: Client.TaskPriority): SxProps{
+  const color = priorityColors[priority];
+  return { color, ':hover': { color }, mr: 1 };
+}
+
+const TaskPriorities: React.FC<{ task: Client.TaskDescriptor, showPriorityText?: boolean }> = ({ task, showPriorityText }) => {
+  const priority = task.priority;
+  const Popover = usePopover();
+
+  return (
+    <Box>
+      <Button variant='text' color='inherit' onClick={Popover.onClick} sx={{ textTransform: 'none' }}>
+        <EmojiFlagsIcon sx={getPrioritySx(priority)} />
+        {showPriorityText && <Typography><FormattedMessage id={'task.priority.' + priority} /></Typography>}
+      </Button>
+      <Popover.Delegate>
+        <MenuList dense>
+          {priorityOptions.map((option: Client.TaskPriority) => (
+            <MenuItem key={option} onClick={Popover.onClose}>
+              <EmojiFlagsIcon sx={getPrioritySx(option)} />
+              <ListItemText><FormattedMessage id={'task.priority.' + option} /></ListItemText>
+            </MenuItem>
+          ))}
+        </MenuList>
+      </Popover.Delegate>
+    </Box>
+  );
+}
+
+export default TaskPriorities;

--- a/mvn_setup/tasks-parent/tasks-ui/src/core/TaskPriority/index.tsx
+++ b/mvn_setup/tasks-parent/tasks-ui/src/core/TaskPriority/index.tsx
@@ -14,7 +14,7 @@ function getPrioritySx(priority: Client.TaskPriority): SxProps{
   return { color, ':hover': { color }, mr: 1 };
 }
 
-const TaskPriorities: React.FC<{ task: Client.TaskDescriptor, showPriorityText?: boolean }> = ({ task, showPriorityText }) => {
+const TaskPriority: React.FC<{ task: Client.TaskDescriptor, priorityTextEnabled?: boolean }> = ({ task, priorityTextEnabled }) => {
   const priority = task.priority;
   const Popover = usePopover();
 
@@ -22,7 +22,7 @@ const TaskPriorities: React.FC<{ task: Client.TaskDescriptor, showPriorityText?:
     <Box>
       <Button variant='text' color='inherit' onClick={Popover.onClick} sx={{ textTransform: 'none' }}>
         <EmojiFlagsIcon sx={getPrioritySx(priority)} />
-        {showPriorityText && <Typography><FormattedMessage id={'task.priority.' + priority} /></Typography>}
+        {priorityTextEnabled && <Typography><FormattedMessage id={'task.priority.' + priority} /></Typography>}
       </Button>
       <Popover.Delegate>
         <MenuList dense>
@@ -38,4 +38,4 @@ const TaskPriorities: React.FC<{ task: Client.TaskDescriptor, showPriorityText?:
   );
 }
 
-export default TaskPriorities;
+export default TaskPriority;

--- a/mvn_setup/tasks-parent/tasks-ui/src/core/TaskTable/CellPriority.tsx
+++ b/mvn_setup/tasks-parent/tasks-ui/src/core/TaskTable/CellPriority.tsx
@@ -1,66 +1,16 @@
 import React from 'react';
-import { SxProps, IconButton, MenuList, MenuItem, ListItemText, Divider } from '@mui/material';
-import AssistantPhotoTwoToneIcon from '@mui/icons-material/AssistantPhotoTwoTone';
-import { useIntl } from 'react-intl';
 
-import client from '@taskclient';
-import TaskCell from './TaskCell';
-import { usePopover } from './CellPopover';
-import { CellProps } from './task-table-types';
+import Client from '@taskclient';
 import { StyledTableCell } from './StyledTable';
-
-
-
-function getPriority(def: client.Group): SxProps | undefined {
-  if (!def.color) {
-    return undefined;
-  }
-  if (def.type === 'priority') {
-    const backgroundColor = def.color;
-    return { backgroundColor, borderWidth: 0, color: 'primary.contrastText' }
-  }
-  return undefined;
-}
-
-const Priority: React.FC<CellProps & { color?: string }> = ({ row, color }) => {
-  const intl = useIntl();
-  const value = intl.formatMessage({ id: `tasktable.header.spotlight.priority.${row.priority}` }).toUpperCase();
-
-  const Popover = usePopover();
-
-
-  return (
-    <>
-      <Popover.Delegate>
-        <MenuList dense>
-          <MenuItem>
-            <ListItemText>High</ListItemText>
-          </MenuItem>
-          <MenuItem>
-            <ListItemText>Normal</ListItemText>
-          </MenuItem>
-          <MenuItem>
-            <ListItemText>Low</ListItemText>
-          </MenuItem>
-          <Divider />
-          <MenuItem>
-            <ListItemText>None</ListItemText>
-          </MenuItem>
-        </MenuList>
-      </Popover.Delegate>
-      <TaskCell id={row.id + "/Priority"} name={<IconButton onClick={Popover.onClick}><AssistantPhotoTwoToneIcon sx={{ fontSize: 'medium', color }} /></IconButton>} />
-
-    </>
-  );
-}
+import TaskPriorities from 'core/TaskPriorities';
 
 const FormattedCell: React.FC<{
   rowId: number,
-  row: client.TaskDescriptor,
-  def: client.Group
-}> = ({ row, def }) => {
+  row: Client.TaskDescriptor,
+  def: Client.Group
+}> = ({ row }) => {
 
-  return (<StyledTableCell width="50px" sx={getPriority(def)}><Priority row={row} def={def} /></StyledTableCell>);
+  return (<StyledTableCell width="50px" ><TaskPriorities task={row} /></StyledTableCell>);
 }
 
 export default FormattedCell;

--- a/mvn_setup/tasks-parent/tasks-ui/src/core/TaskTable/CellPriority.tsx
+++ b/mvn_setup/tasks-parent/tasks-ui/src/core/TaskTable/CellPriority.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import Client from '@taskclient';
 import { StyledTableCell } from './StyledTable';
-import TaskPriorities from 'core/TaskPriorities';
+import TaskPriority from 'core/TaskPriority';
 
 const FormattedCell: React.FC<{
   rowId: number,
@@ -10,7 +10,7 @@ const FormattedCell: React.FC<{
   def: Client.Group
 }> = ({ row }) => {
 
-  return (<StyledTableCell width="50px" ><TaskPriorities task={row} /></StyledTableCell>);
+  return (<StyledTableCell width="50px" ><TaskPriority task={row} /></StyledTableCell>);
 }
 
 export default FormattedCell;


### PR DESCRIPTION
Created a Popover menu for priorities similar to the menu that has already been made inside the task edit dialog.
Only difference being that inside the task cell only the flag is being shown and not the text.
I made a separate component for the TaskPriorities because it is being used in two different folders and the code is the same except just one line, which I handled with a showPriorityText attribute.
So in edit dialog this new component is also used now, which reduces the code repetition.

**Screenshots**

![image](https://github.com/digiexpress-io/digiexpress-parent/assets/37162148/49a7b7d9-0c98-4bff-bdac-591c42316aa2)

![image](https://github.com/digiexpress-io/digiexpress-parent/assets/37162148/7f3dc1b4-58af-44d0-bd90-534120ef1f55)

![image](https://github.com/digiexpress-io/digiexpress-parent/assets/37162148/b13f0aec-dca9-47eb-a17d-8ad99df68fef)
