### PR TITLE
TaskTable popover menu for the statuses

### DIFF
--- a/mvn_setup/tasks-parent/tasks-ui/src/core/TaskEdit/TaskEditFields.tsx
+++ b/mvn_setup/tasks-parent/tasks-ui/src/core/TaskEdit/TaskEditFields.tsx
@@ -17,7 +17,7 @@ import TaskClient from '@taskclient';
 import ChecklistDelegate from 'core/Checklist';
 import { usePopover } from 'core/TaskTable/CellPopover';
 import TaskAssignees from 'core/TaskAssignees';
-import TaskStatuses from 'core/TaskStatuses';
+import TaskStatus from 'core/TaskStatus';
 
 
 const Title: React.FC<{}> = () => {
@@ -68,7 +68,7 @@ const Status: React.FC<{}> = () => {
   const { state } = TaskClient.useTaskEdit();
 
   return (
-    <TaskStatuses task={state.task}/>
+    <TaskStatus task={state.task}/>
   )
 }
 

--- a/mvn_setup/tasks-parent/tasks-ui/src/core/TaskEdit/TaskEditFields.tsx
+++ b/mvn_setup/tasks-parent/tasks-ui/src/core/TaskEdit/TaskEditFields.tsx
@@ -9,7 +9,6 @@ import DateRangeOutlinedIcon from '@mui/icons-material/DateRangeOutlined';
 import MailOutlineIcon from '@mui/icons-material/MailOutline';
 import AttachFileIcon from '@mui/icons-material/AttachFile';
 import CircleNotificationsOutlinedIcon from '@mui/icons-material/CircleNotificationsOutlined';
-import CircleIcon from '@mui/icons-material/Circle';
 import EmojiFlagsIcon from '@mui/icons-material/EmojiFlags';
 import CloseIcon from '@mui/icons-material/Close';
 
@@ -18,6 +17,7 @@ import TaskClient from '@taskclient';
 import ChecklistDelegate from 'core/Checklist';
 import { usePopover } from 'core/TaskTable/CellPopover';
 import TaskAssignees from 'core/TaskAssignees';
+import TaskStatuses from 'core/TaskStatuses';
 
 
 const Title: React.FC<{}> = () => {
@@ -52,20 +52,6 @@ const Checklist: React.FC<{}> = () => {
   )
 }
 
-const getStatusColorConfig = (status: TaskClient.TaskStatus): SxProps => {
-  const statusColors = TaskClient.StatusPallette;
-  switch (status) {
-    case 'COMPLETED':
-      return { color: statusColors.COMPLETED, ':hover': { color: statusColors.COMPLETED } };
-    case 'CREATED':
-      return { color: statusColors.CREATED, ':hover': { color: statusColors.CREATED } };
-    case 'IN_PROGRESS':
-      return { color: statusColors.IN_PROGRESS, ':hover': { color: statusColors.IN_PROGRESS } };
-    case 'REJECTED':
-      return { color: statusColors.REJECTED, ':hover': { color: statusColors.REJECTED } };
-  }
-}
-
 const getPriorityColorConfig = (priority: TaskClient.TaskPriority): SxProps => {
   const priorityColors = TaskClient.PriorityPalette;
   switch (priority) {
@@ -80,27 +66,9 @@ const getPriorityColorConfig = (priority: TaskClient.TaskPriority): SxProps => {
 
 const Status: React.FC<{}> = () => {
   const { state } = TaskClient.useTaskEdit();
-  const status = state.task.status;
-  const Popover = usePopover();
-  const statusOptions: TaskClient.TaskStatus[] = ['CREATED', 'IN_PROGRESS', 'COMPLETED', 'REJECTED'];
 
   return (
-    <Box>
-      <Button variant='text' color='inherit' onClick={Popover.onClick} sx={{ textTransform: 'none' }}>
-        <CircleIcon sx={{ mr: 1, ...getStatusColorConfig(status) }} />
-        <Typography><FormattedMessage id={'task.status.' + status} /></Typography>
-      </Button>
-      <Popover.Delegate>
-        <MenuList dense>
-          {statusOptions.map(option => (
-            <MenuItem key={option} onClick={Popover.onClose}>
-              <CircleIcon sx={{ alignItems: 'center', mr: 1, ...getStatusColorConfig(option) }} />
-              <ListItemText><FormattedMessage id={'task.status.' + option} /></ListItemText>
-            </MenuItem>
-          ))}
-        </MenuList>
-      </Popover.Delegate>
-    </Box>
+    <TaskStatuses task={state.task}/>
   )
 }
 

--- a/mvn_setup/tasks-parent/tasks-ui/src/core/TaskStatus/index.tsx
+++ b/mvn_setup/tasks-parent/tasks-ui/src/core/TaskStatus/index.tsx
@@ -10,7 +10,7 @@ function getStatusBackgroundColor(status: Client.TaskStatus): string {
   return color;
 }
 
-const TaskStatuses: React.FC<{ task: Client.TaskDescriptor }> = ({ task }) => {
+const TaskStatus: React.FC<{ task: Client.TaskDescriptor }> = ({ task }) => {
   const intl = useIntl();
   const Popover = useMockPopover();
   const statusLabel = intl.formatMessage({ id: `tasktable.header.spotlight.status.${task.status}` }).toUpperCase();
@@ -48,4 +48,4 @@ const TaskStatuses: React.FC<{ task: Client.TaskDescriptor }> = ({ task }) => {
   );
 }
 
-export default TaskStatuses;
+export default TaskStatus;

--- a/mvn_setup/tasks-parent/tasks-ui/src/core/TaskStatus/index.tsx
+++ b/mvn_setup/tasks-parent/tasks-ui/src/core/TaskStatus/index.tsx
@@ -5,8 +5,16 @@ import { FormattedMessage, useIntl } from 'react-intl';
 import Client from '@taskclient';
 import { useMockPopover } from 'core/TaskTable/MockPopover';
 
+const statusOptions: Client.TaskStatus[] = ['CREATED', 'IN_PROGRESS', 'COMPLETED', 'REJECTED'];
+
 function getStatusBackgroundColor(status: Client.TaskStatus): string {
-  const color = Client.StatusPallette[status] || "unset";
+  const color = Client.StatusPallette[status];
+  return color;
+}
+
+function getActiveColor(currentlyShowing: Client.TaskStatus, status: Client.TaskStatus): string {
+  const selectedTaskStatusColor = Client.StatusPallette.IN_PROGRESS;
+  const color = status === currentlyShowing ? selectedTaskStatusColor : "unset";
   return color;
 }
 
@@ -14,12 +22,6 @@ const TaskStatus: React.FC<{ task: Client.TaskDescriptor }> = ({ task }) => {
   const intl = useIntl();
   const Popover = useMockPopover();
   const statusLabel = intl.formatMessage({ id: `tasktable.header.spotlight.status.${task.status}` }).toUpperCase();
-  const statusOptions: Client.TaskStatus[] = ['CREATED', 'IN_PROGRESS', 'COMPLETED', 'REJECTED'];
-
-  function getActiveColor(option: Client.TaskStatus): string {
-    const color = task.status === option ? Client.StatusPallette.IN_PROGRESS : "unset";
-    return color;
-  }
 
   return (
     <Box>
@@ -38,7 +40,7 @@ const TaskStatus: React.FC<{ task: Client.TaskDescriptor }> = ({ task }) => {
           {statusOptions.map((option: Client.TaskStatus) => (
             <MenuItem key={option} onClick={Popover.onClose} sx={{ display: "flex", pl: 0, py: 0 }}>
               <Box sx={{ width: 8, height: 40, backgroundColor: getStatusBackgroundColor(option)}} />
-              <Box sx={{ width: 8, height: 8, borderRadius: "50%", mx: 2, backgroundColor: getActiveColor(option)}} />
+              <Box sx={{ width: 8, height: 8, borderRadius: "50%", mx: 2, backgroundColor: getActiveColor(option, task.status)}} />
               <ListItemText><FormattedMessage id={`task.status.${option}`} /></ListItemText>
             </MenuItem>
           ))}

--- a/mvn_setup/tasks-parent/tasks-ui/src/core/TaskStatuses/index.tsx
+++ b/mvn_setup/tasks-parent/tasks-ui/src/core/TaskStatuses/index.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import { Chip, MenuItem, List, Box, ListItemText } from '@mui/material';
+import { FormattedMessage, useIntl } from 'react-intl';
+
+import Client from '@taskclient';
+import { useMockPopover } from 'core/TaskTable/MockPopover';
+
+function getStatusBackgroundColor(status: Client.TaskStatus): string {
+  const color = Client.StatusPallette[status] || "unset";
+  return color;
+}
+
+const TaskStatuses: React.FC<{ task: Client.TaskDescriptor }> = ({ task }) => {
+  const intl = useIntl();
+  const Popover = useMockPopover();
+  const statusLabel = intl.formatMessage({ id: `tasktable.header.spotlight.status.${task.status}` }).toUpperCase();
+  const statusOptions: Client.TaskStatus[] = ['CREATED', 'IN_PROGRESS', 'COMPLETED', 'REJECTED'];
+
+  function getActiveColor(option: Client.TaskStatus): string {
+    const color = task.status === option ? Client.StatusPallette.IN_PROGRESS : "unset";
+    return color;
+  }
+
+  return (
+    <Box>
+      <Chip 
+        onClick={Popover.onClick} 
+        label={statusLabel}
+        sx={{
+          backgroundColor: getStatusBackgroundColor(task.status), 
+          color: "primary.contrastText",
+          ml: 0,
+          ":hover": { backgroundColor: "#404c64"}
+        }} 
+      />
+      <Popover.Delegate>
+        <List dense sx={{ py: 0 }}>
+          {statusOptions.map((option: Client.TaskStatus) => (
+            <MenuItem key={option} onClick={Popover.onClose} sx={{ display: "flex", pl: 0, py: 0 }}>
+              <Box sx={{ width: 8, height: 40, backgroundColor: getStatusBackgroundColor(option)}} />
+              <Box sx={{ width: 8, height: 8, borderRadius: "50%", mx: 2, backgroundColor: getActiveColor(option)}} />
+              <ListItemText><FormattedMessage id={`task.status.${option}`} /></ListItemText>
+            </MenuItem>
+          ))}
+        </List>
+      </Popover.Delegate>
+    </Box>
+  );
+}
+
+export default TaskStatuses;

--- a/mvn_setup/tasks-parent/tasks-ui/src/core/TaskTable/CellStatus.tsx
+++ b/mvn_setup/tasks-parent/tasks-ui/src/core/TaskTable/CellStatus.tsx
@@ -1,41 +1,18 @@
 import React from 'react';
-import { SxProps } from '@mui/material';
-import { useIntl } from 'react-intl';
 
-import client from '@taskclient';
-import TaskCell from './TaskCell';
-import { usePopover } from './CellPopover';
-import { CellProps } from './task-table-types';
+import Client from '@taskclient';
+
 import { StyledTableCell } from './StyledTable';
-
-
-
-function getStatus(def: client.Group): SxProps | undefined {
-  if (!def.color) {
-    return undefined;
-  }
-  if (def.type === 'status') {
-    const backgroundColor = def.color;
-    return { backgroundColor, borderWidth: 0, color: 'primary.contrastText' }
-  }
-  return undefined;
-}
-
-const Status: React.FC<CellProps> = ({ row }) => {
-  const intl = useIntl();
-  const value = intl.formatMessage({ id: `tasktable.header.spotlight.status.${row.status}` }).toUpperCase();
-  return (<TaskCell id={row.id + "/Status"} name={value} />);
-}
-
+import TaskStatuses from 'core/TaskStatuses';
 
 const FormattedCell: React.FC<{
   rowId: number,
-  row: client.TaskDescriptor,
-  def: client.Group
-}> = ({ row, def }) => {
+  row: Client.TaskDescriptor,
+  def: Client.Group
+}> = ({ row }) => {
 
   return (
-    <StyledTableCell width="100px" sx={getStatus(def)}><Status row={row} def={def} /></StyledTableCell>
+    <StyledTableCell width="100px" sx={{ pl: 0 }}><TaskStatuses task={row} /></StyledTableCell>
   );
 }
 

--- a/mvn_setup/tasks-parent/tasks-ui/src/core/TaskTable/CellStatus.tsx
+++ b/mvn_setup/tasks-parent/tasks-ui/src/core/TaskTable/CellStatus.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import Client from '@taskclient';
 
 import { StyledTableCell } from './StyledTable';
-import TaskStatuses from 'core/TaskStatuses';
+import TaskStatus from 'core/TaskStatus';
 
 const FormattedCell: React.FC<{
   rowId: number,
@@ -12,7 +12,7 @@ const FormattedCell: React.FC<{
 }> = ({ row }) => {
 
   return (
-    <StyledTableCell width="100px" sx={{ pl: 0 }}><TaskStatuses task={row} /></StyledTableCell>
+    <StyledTableCell width="100px" sx={{ pl: 0 }}><TaskStatus task={row} /></StyledTableCell>
   );
 }
 

--- a/mvn_setup/tasks-parent/tasks-ui/src/core/TaskTable/MockPopover.tsx
+++ b/mvn_setup/tasks-parent/tasks-ui/src/core/TaskTable/MockPopover.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import { Box, Popover, PopoverOrigin } from '@mui/material';
+
+
+interface TablePopoverProps {
+  open: boolean,
+  onClose: () => void,
+  children: React.ReactNode,
+  anchorEl: HTMLElement | null,
+  anchorOrigin?: PopoverOrigin,
+  transformOrigin?: PopoverOrigin
+}
+
+const useMockPopover = () => {
+  const [anchorEl, setAnchorEl] = React.useState<HTMLElement | null>(null);
+  const open = Boolean(anchorEl);
+
+  const handleClick = React.useCallback((event: React.MouseEvent<HTMLElement>) => {
+    setAnchorEl(event.currentTarget);
+  }, [setAnchorEl]);
+
+  const handleClose = React.useCallback(() => {
+    setAnchorEl(null);
+  }, [setAnchorEl]);
+
+
+  const Delegate: React.FC<{ children: React.ReactNode }> = React.useCallback(({ children }) => {
+    return (<TablePopover open={open} onClose={handleClose} anchorEl={anchorEl}>
+      {children}
+    </TablePopover>)
+  }, [open, handleClose, anchorEl])
+
+  return { Delegate, onClick: handleClick, onClose: handleClose };
+}
+
+const TablePopover: React.FC<TablePopoverProps> = ({ children, anchorEl, open, onClose }) => {
+
+  return (
+    <Popover open={open} onClose={onClose} anchorEl={anchorEl}
+      anchorOrigin={{
+        vertical: 'bottom',
+        horizontal: 'right',
+      }}
+      transformOrigin={{
+        vertical: 'top',
+        horizontal: 'right',
+      }}>
+      <Box sx={{ p: 0 }}>
+        {children}
+      </Box>
+
+    </Popover>
+  );
+}
+
+export { useMockPopover };


### PR DESCRIPTION
Now initially when the table is shown in AdminBoard status is shown in a MUI Chip component with proper background color.
After clicking on it, popover menu is being opened.
This popover has specific style, going from left to right for each MenuItem, first there is a Box showing a color of the status vertically, then a Box showing which status is active and then the status label.
MockPopover component is created to allow using this test style, which is only different from CellPopover because of zero padding.
This new TaskStatuses component is now also used in the EditDialog in the same way as in TaskTable.

### **Screenshots**

**_EditDialog before:_**

![image](https://github.com/digiexpress-io/digiexpress-parent/assets/37162148/f9cb289b-8abd-4838-ae48-182870d3f0b1)

![image](https://github.com/digiexpress-io/digiexpress-parent/assets/37162148/bef906e3-ee43-4b4b-9bf3-f18fe7d350b1)

**_EditDialog now:_**

![image](https://github.com/digiexpress-io/digiexpress-parent/assets/37162148/b39f8632-f9ca-40c6-abd3-89f2831bd5ba)

![image](https://github.com/digiexpress-io/digiexpress-parent/assets/37162148/d686f306-1ff9-4378-8617-5ad8546e8a8f)

**_TaskTable now:_**

![image](https://github.com/digiexpress-io/digiexpress-parent/assets/37162148/f2e02881-9195-4ab5-8b6a-328050b32773)

![image](https://github.com/digiexpress-io/digiexpress-parent/assets/37162148/ac25de3c-e711-4bcd-a983-959d289027d3)


