### PR TITLE
Implemented new style for task priority popover

### DIFF
--- a/mvn_setup/tasks-parent/tasks-ui/src/core/TaskPriority/index.tsx
+++ b/mvn_setup/tasks-parent/tasks-ui/src/core/TaskPriority/index.tsx
@@ -1,38 +1,46 @@
 import React from 'react';
-import { SxProps, MenuList, MenuItem, ListItemText, Box, Button, Typography } from '@mui/material';
+import { SxProps, List,  MenuItem, ListItemText, Box, Button, Typography } from '@mui/material';
 import EmojiFlagsIcon from '@mui/icons-material/EmojiFlags';
 import { FormattedMessage } from 'react-intl';
 
 import Client from '@taskclient';
-import { usePopover } from 'core/TaskTable/CellPopover';
+import { useMockPopover } from 'core/TaskTable/MockPopover';
 
 const priorityColors = Client.PriorityPalette;
+const statusColors = Client.StatusPallette;
 const priorityOptions: Client.TaskPriority[] = ['LOW', 'HIGH', 'MEDIUM'];
 
-function getPrioritySx(priority: Client.TaskPriority): SxProps{
+function getEmojiFlagSx(priority: Client.TaskPriority): SxProps{
   const color = priorityColors[priority];
   return { color, ':hover': { color }, mr: 1 };
 }
 
+function getActiveColor(currentlyShowing: Client.TaskPriority, priority: Client.TaskPriority): string {
+  const selectedItemColor = statusColors.IN_PROGRESS;
+  const color = priority === currentlyShowing ? selectedItemColor : "unset";
+  return color;
+}
+
 const TaskPriority: React.FC<{ task: Client.TaskDescriptor, priorityTextEnabled?: boolean }> = ({ task, priorityTextEnabled }) => {
   const priority = task.priority;
-  const Popover = usePopover();
+  const Popover = useMockPopover();
 
   return (
     <Box>
       <Button variant='text' color='inherit' onClick={Popover.onClick} sx={{ textTransform: 'none' }}>
-        <EmojiFlagsIcon sx={getPrioritySx(priority)} />
+        <EmojiFlagsIcon sx={getEmojiFlagSx(priority)} />
         {priorityTextEnabled && <Typography><FormattedMessage id={'task.priority.' + priority} /></Typography>}
       </Button>
       <Popover.Delegate>
-        <MenuList dense>
+        <List dense sx={{ py: 0 }}>
           {priorityOptions.map((option: Client.TaskPriority) => (
-            <MenuItem key={option} onClick={Popover.onClose}>
-              <EmojiFlagsIcon sx={getPrioritySx(option)} />
-              <ListItemText><FormattedMessage id={'task.priority.' + option} /></ListItemText>
+            <MenuItem key={option} onClick={Popover.onClose} sx={{ display: "flex", pl: 0, py: 0 }}>
+              <Box sx={{ width: 8, height: 40, backgroundColor: priorityColors[option]}} />
+              <Box sx={{ width: 8, height: 8, borderRadius: "50%", mx: 2, backgroundColor: getActiveColor(option, priority)}} />
+              <ListItemText><FormattedMessage id={`task.priority.${option}`} /></ListItemText>
             </MenuItem>
           ))}
-        </MenuList>
+        </List>
       </Popover.Delegate>
     </Box>
   );

--- a/mvn_setup/tasks-parent/tasks-ui/src/core/TaskPriority/index.tsx
+++ b/mvn_setup/tasks-parent/tasks-ui/src/core/TaskPriority/index.tsx
@@ -7,7 +7,6 @@ import Client from '@taskclient';
 import { useMockPopover } from 'core/TaskTable/MockPopover';
 
 const priorityColors = Client.PriorityPalette;
-const statusColors = Client.StatusPallette;
 const priorityOptions: Client.TaskPriority[] = ['LOW', 'HIGH', 'MEDIUM'];
 
 function getEmojiFlagSx(priority: Client.TaskPriority): SxProps{
@@ -16,7 +15,7 @@ function getEmojiFlagSx(priority: Client.TaskPriority): SxProps{
 }
 
 function getActiveColor(currentlyShowing: Client.TaskPriority, priority: Client.TaskPriority): string {
-  const selectedItemColor = statusColors.IN_PROGRESS;
+  const selectedItemColor = Client.StatusPallette.IN_PROGRESS;
   const color = priority === currentlyShowing ? selectedItemColor : "unset";
   return color;
 }

--- a/mvn_setup/tasks-parent/tasks-ui/src/core/TaskStatus/index.tsx
+++ b/mvn_setup/tasks-parent/tasks-ui/src/core/TaskStatus/index.tsx
@@ -5,23 +5,20 @@ import { FormattedMessage, useIntl } from 'react-intl';
 import Client from '@taskclient';
 import { useMockPopover } from 'core/TaskTable/MockPopover';
 
+const statusColors = Client.StatusPallette;
 const statusOptions: Client.TaskStatus[] = ['CREATED', 'IN_PROGRESS', 'COMPLETED', 'REJECTED'];
 
-function getStatusBackgroundColor(status: Client.TaskStatus): string {
-  const color = Client.StatusPallette[status];
-  return color;
-}
-
 function getActiveColor(currentlyShowing: Client.TaskStatus, status: Client.TaskStatus): string {
-  const selectedTaskStatusColor = Client.StatusPallette.IN_PROGRESS;
+  const selectedTaskStatusColor = statusColors.IN_PROGRESS;
   const color = status === currentlyShowing ? selectedTaskStatusColor : "unset";
   return color;
 }
 
 const TaskStatus: React.FC<{ task: Client.TaskDescriptor }> = ({ task }) => {
+  const status = task.status;
   const intl = useIntl();
   const Popover = useMockPopover();
-  const statusLabel = intl.formatMessage({ id: `tasktable.header.spotlight.status.${task.status}` }).toUpperCase();
+  const statusLabel = intl.formatMessage({ id: `tasktable.header.spotlight.status.${status}` }).toUpperCase();
 
   return (
     <Box>
@@ -29,7 +26,7 @@ const TaskStatus: React.FC<{ task: Client.TaskDescriptor }> = ({ task }) => {
         onClick={Popover.onClick} 
         label={statusLabel}
         sx={{
-          backgroundColor: getStatusBackgroundColor(task.status), 
+          backgroundColor: statusColors[status], 
           color: "primary.contrastText",
           ml: 0,
           ":hover": { backgroundColor: "#404c64"}
@@ -39,8 +36,8 @@ const TaskStatus: React.FC<{ task: Client.TaskDescriptor }> = ({ task }) => {
         <List dense sx={{ py: 0 }}>
           {statusOptions.map((option: Client.TaskStatus) => (
             <MenuItem key={option} onClick={Popover.onClose} sx={{ display: "flex", pl: 0, py: 0 }}>
-              <Box sx={{ width: 8, height: 40, backgroundColor: getStatusBackgroundColor(option)}} />
-              <Box sx={{ width: 8, height: 8, borderRadius: "50%", mx: 2, backgroundColor: getActiveColor(option, task.status)}} />
+              <Box sx={{ width: 8, height: 40, backgroundColor: statusColors[option]}} />
+              <Box sx={{ width: 8, height: 8, borderRadius: "50%", mx: 2, backgroundColor: getActiveColor(option, status)}} />
               <ListItemText><FormattedMessage id={`task.status.${option}`} /></ListItemText>
             </MenuItem>
           ))}


### PR DESCRIPTION
New style from task status is now implemented for task priority Popover items (vertical color, active item indicator, item text).
Some small code changes also to reduce code or reduce complexity of the task priority component.
Some code reduction added in task status component, the background color function is not needed.

### **Screenshots**

### Before

![image](https://github.com/digiexpress-io/digiexpress-parent/assets/37162148/f6c1d23a-ea5e-4ef4-a75f-8c81dd8b98f5)

### After

![image](https://github.com/digiexpress-io/digiexpress-parent/assets/37162148/a25e0065-0545-46b7-abab-d32605b3baca)

