### PR TITLE
Fix code scanning alert no. 2: Incomplete string escaping or encoding

### DIFF
--- a/ts_setup/gamut/src/api-dialob/impl-form.ts
+++ b/ts_setup/gamut/src/api-dialob/impl-form.ts
@@ -77,8 +77,8 @@ export class FormImpl implements DialobApi.Form {
     if (!sessionItem.description || sessionItem.description?.trim().length === 0) {
       return undefined;
     }
-    // \r\n = windows line break, \n' = unix line break, \u200B unicode zero-width space
-    if (sessionItem.description.replace('\r\n', '').replace('\n', '').replace('\u200B', '').trim().length === 0) {
+    // \r\n = windows line break, \n = unix line break, \u200B = unicode zero-width space
+    if (sessionItem.description.replace(/\r\n/g, '').replace(/\n/g, '').replace(/\u200B/g, '').trim().length === 0) {
       return undefined;
     }
     return sessionItem.description;


### PR DESCRIPTION
Fixes [https://github.com/digiexpress-io/digiexpress-parent/security/code-scanning/2](https://github.com/digiexpress-io/digiexpress-parent/security/code-scanning/2)

To fix the problem, we need to ensure that all occurrences of the specified substrings (`\r\n`, `\n`, `\u200B`) are replaced. This can be achieved by using regular expressions with the global flag (`g`). This change will ensure that every instance of the specified substrings is removed from the `sessionItem.description`.

The changes will be made in the `toDescription` method of the `FormImpl` class in the file `ts_setup/gamut/src/api-dialob/impl-form.ts`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
