### PR TITLE
Tagomi PDF docker build

### DIFF
--- a/.github/workflows/tagomi-pdf-release.yml
+++ b/.github/workflows/tagomi-pdf-release.yml
@@ -1,0 +1,142 @@
+name: Build and Deploy Tagomi PDF
+
+permissions:
+  contents: write
+
+on:
+  workflow_dispatch:
+    inputs:
+      version_bump:
+        description: 'Version bump type'
+        required: true
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+        default: 'patch'
+
+env:
+  APP_PATH: rust_setup/crates/tagomi-pdf
+  IMAGE_NAME: digiexpress-io/tagomi-pdf
+  GIT_USERNAME: github-actions[bot]
+  GIT_EMAIL: github-actions[bot]@users.noreply.github.com
+  TAG_PREFIX: tagomi-pdf/v
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Read and increment version
+        id: version
+        run: |
+          # Read version from Cargo.toml
+          CURRENT_VERSION=$(grep '^version = ' ${{ env.APP_PATH }}/Cargo.toml | head -1 | sed 's/version = "\(.*\)"/\1/')
+          
+          if [[ $CURRENT_VERSION =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
+            MAJOR="${BASH_REMATCH[1]}"
+            MINOR="${BASH_REMATCH[2]}"
+            PATCH="${BASH_REMATCH[3]}"
+          else
+            echo "Invalid semantic version: $CURRENT_VERSION"
+            exit 1
+          fi
+          
+          case "${{ github.event.inputs.version_bump }}" in
+            major)
+              MAJOR=$((MAJOR + 1))
+              MINOR=0
+              PATCH=0
+              ;;
+            minor)
+              MINOR=$((MINOR + 1))
+              PATCH=0
+              ;;
+            patch)
+              PATCH=$((PATCH + 1))
+              ;;
+          esac
+          
+          NEW_VERSION="${MAJOR}.${MINOR}.${PATCH}"
+          echo "Bumping version from $CURRENT_VERSION to $NEW_VERSION (${{ github.event.inputs.version_bump }} bump)"
+
+          echo "version=$NEW_VERSION" >> $GITHUB_OUTPUT
+          echo "tag=${{ env.TAG_PREFIX }}$NEW_VERSION" >> $GITHUB_OUTPUT
+
+      - name: Check if tag already exists
+        id: check_tag
+        run: |
+          if git rev-parse "${{ steps.version.outputs.tag }}" >/dev/null 2>&1; then
+            echo "Tag ${{ steps.version.outputs.tag }} already exists. Aborting workflow."
+            exit 1
+          else
+            echo "Tag ${{ steps.version.outputs.tag }} does not exist, creating tag."
+          fi
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to ReSys Docker Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ secrets.DOCKER_REGISTRY }}
+          username: ${{ secrets.DOCKER_REGISTRY_USERNAME }}
+          password: ${{ secrets.DOCKER_REGISTRY_PASSWORD }}
+
+      - name: Extract metadata (tags, labels)
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ secrets.DOCKER_REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=semver,pattern={{version}},value=v${{ steps.version.outputs.version }}
+            type=sha,prefix={{branch}}-
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: ${{ env.APP_PATH }}
+          file: ${{ env.APP_PATH }}/Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Push new version and tag to git
+        run: |
+          # Update Cargo.toml version
+          sed -i "s/^version = \".*\"/version = \"${{ steps.version.outputs.version }}\"/" ${{ env.APP_PATH }}/Cargo.toml
+          
+          # Update version.json for badge display
+          echo "{\"version\": \"${{ steps.version.outputs.version }}\"}" > ${{ env.APP_PATH }}/version.json
+
+          git config --global user.name "${{ env.GIT_USERNAME }}"
+          git config --global user.email "${{ env.GIT_EMAIL }}"
+          
+          git add "${{ env.APP_PATH }}/Cargo.toml" "${{ env.APP_PATH }}/version.json"
+          git commit -m "release ${{ env.TAG_PREFIX }}${{ steps.version.outputs.version }}"
+          git push origin ${{ github.ref_name }}
+
+          git tag -a "${{ steps.version.outputs.tag }}" -m "Release version ${{ steps.version.outputs.version }}"
+          git push origin "${{ steps.version.outputs.tag }}"
+
+      - name: Tagomi PDF Release Summary
+        run: |
+          echo "## Tagomi PDF Release Summary" >> $GITHUB_STEP_SUMMARY
+          echo "**Bump type:** \`${{ github.event.inputs.version_bump }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "**New version:** \`${{ steps.version.outputs.version }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "**Tag created:** \`${{ steps.version.outputs.tag }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### Docker Images Created" >> $GITHUB_STEP_SUMMARY
+          IFS=',' read -ra IMAGES <<< "${{ steps.meta.outputs.tags }}"
+          for img in "${IMAGES[@]}"; do
+            echo "- \`${img}\`" >> $GITHUB_STEP_SUMMARY
+          done

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Gamut](https://img.shields.io/npm/v/@dxs-ts/gamut?label=Gamut@latest)](https://www.npmjs.com/package/@dxs-ts/gamut)
 [![Eveli IDE](https://img.shields.io/npm/v/@dxs-ts/eveli-ide?label=Eveli%20IDE@latest)](https://www.npmjs.com/package/@dxs-ts/eveli-ide)
 ![Feedback Analyzer](https://img.shields.io/badge/dynamic/json?url=https://raw.githubusercontent.com/digiexpress-io/digiexpress-parent/dev/py_setup/feedback-analyzer/version.json&query=$.version&label=Feedback%20Analyzer@latest&color=blue&prefix=v)
+![Tagomi PDF](https://img.shields.io/badge/dynamic/json?url=https://raw.githubusercontent.com/digiexpress-io/digiexpress-parent/dev/rust_setup/crates/tagomi-pdf/version.json&query=$.version&label=Tagomi%20PDF@latest&color=blue&prefix=v)
 
 
 # DigiExpress-parent

--- a/mvn_setup/eveli-parent/eveli-local-docker/docker-compose.yaml
+++ b/mvn_setup/eveli-parent/eveli-local-docker/docker-compose.yaml
@@ -121,6 +121,21 @@ services:
     ports:
       - "8083:8000"
 
+  # tagomi pdf compiler
+  tagomi-pdf:
+    build:
+      context: ../../../rust_setup/crates/tagomi-pdf
+      dockerfile: Dockerfile
+    container_name: tagomi-pdf
+    ports:
+      - "8085:8085"
+    environment:
+      - FONTS_PATH=/app/assets/fonts
+      - USE_SYSTEM_FONTS=true
+    volumes:
+      - ../../../rust_setup/crates/tagomi-pdf/assets/fonts:/app/assets/fonts:ro
+    restart: always
+
 networks:
   dialob-backend:
     external: false

--- a/rust_setup/.gitignore
+++ b/rust_setup/.gitignore
@@ -1,0 +1,3 @@
+*.pem
+*.pdf
+certs/

--- a/rust_setup/README.md
+++ b/rust_setup/README.md
@@ -9,10 +9,67 @@ To run the PDF application, navigate to the project directory and execute:
 cargo run
 ```
 
+### Configuration
+
+The application is configured using environment variables:
+
+| Environment Variable | Description | Default |
+|---------------------|-------------|---------|
+| `HTTPS_ENABLED` | Enable HTTPS mode (`true` or `false`) | `false` |
+| `PORT` | Port to listen on | `8085` |
+| `TLS_CERT_PATH` | Path to TLS certificate file | `/etc/tls/cert.pem` |
+| `TLS_KEY_PATH` | Path to TLS private key file | `/etc/tls/key.pem` |
+| `FONTS_PATH` | Path to custom fonts directory | `/assets/fonts` |
+| `USE_SYSTEM_FONTS` | Include system fonts (`true` or `false`) | `true` |
+
+#### Running in HTTP mode (default):
+```bash
+cargo run
+```
+
+#### Running in HTTPS mode:
+```bash
+# Generate test certificates (for development only)
+openssl req -x509 -newkey rsa:4096 -keyout key.pem -out cert.pem -days 365 -nodes -subj "/CN=localhost"
+
+# Run with HTTPS
+HTTPS_ENABLED=true TLS_CERT_PATH=cert.pem TLS_KEY_PATH=key.pem cargo run
+```
+
+#### Running on a custom port:
+```bash
+PORT=9090 cargo run
+```
+
+#### Using custom fonts:
+```bash
+# Use custom fonts in addition to system fonts (default behavior)
+FONTS_PATH=/path/to/fonts cargo run
+
+# Use custom fonts only (disable system fonts)
+FONTS_PATH=/path/to/fonts USE_SYSTEM_FONTS=false cargo run
+
+# Use system fonts only (default if FONTS_PATH not set)
+cargo run
+```
+
+### Running with Docker
+
+```bash
+docker-compose up -d
+```
+
+See [docker-compose.README.md](crates/tagomi-pdf/docker-compose.README.md) for more details.
+
+
 ### Calling endpoints
 
 ```bash
- curl -X GET http://localhost:8085/health
+# HTTP mode
+curl -X GET http://localhost:8085/health
+
+# HTTPS mode (with self-signed certificate)
+curl -k -X GET https://localhost:8085/health
 ```
 
 ```bash

--- a/rust_setup/crates/tagomi-pdf/.dockerignore
+++ b/rust_setup/crates/tagomi-pdf/.dockerignore
@@ -1,0 +1,8 @@
+target/
+*.pem
+.gitignore
+*.md
+docker-compose.yml
+docker-compose.README.md
+certs/
+

--- a/rust_setup/crates/tagomi-pdf/Cargo.lock
+++ b/rust_setup/crates/tagomi-pdf/Cargo.lock
@@ -42,6 +42,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "arc-swap"
+version = "1.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457"
+
+[[package]]
 name = "arrayref"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -126,6 +132,27 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "axum-server"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1ab4a3ec9ea8a657c72d99a03a824af695bd0fb5ec639ccbd9cd3543b41a5f9"
+dependencies = [
+ "arc-swap",
+ "bytes",
+ "fs-err",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-util",
+ "openssl",
+ "openssl-sys",
+ "pin-project-lite",
+ "tokio",
+ "tokio-openssl",
+ "tower-service",
 ]
 
 [[package]]
@@ -720,6 +747,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs-err"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62d91fd049c123429b018c47887d3f75a265540dd3c30ba9cb7bae9197edb03a"
+dependencies = [
+ "autocfg",
+ "tokio",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -789,6 +826,25 @@ checksum = "4ae047235e33e2829703574b54fdec96bfbad892062d97fed2f76022287de61b"
 dependencies = [
  "color_quant",
  "weezl",
+]
+
+[[package]]
+name = "h2"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3c0b69cfcb4e1b9f1bf2f53f95f766e4661169728ec61cd3fe5a0166f2d1386"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
 ]
 
 [[package]]
@@ -899,6 +955,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
+ "h2",
  "http",
  "http-body",
  "httparse",
@@ -2288,6 +2345,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "slab"
+version = "0.4.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
+
+[[package]]
 name = "slotmap"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2477,6 +2540,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "axum",
+ "axum-server",
  "base64",
  "chrono",
  "ecow",
@@ -2694,6 +2758,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tokio-openssl"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59df6849caa43bb7567f9a36f863c447d95a11d5903c9cc334ba32576a27eadd"
+dependencies = [
+ "openssl",
+ "openssl-sys",
+ "tokio",
 ]
 
 [[package]]

--- a/rust_setup/crates/tagomi-pdf/Cargo.toml
+++ b/rust_setup/crates/tagomi-pdf/Cargo.toml
@@ -38,3 +38,6 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 # File handling
 tempfile = "3.23.0"
 base64 = "0.22"
+
+# HTTPS/TLS support
+axum-server = { version = "0.7", features = ["tls-openssl"] }

--- a/rust_setup/crates/tagomi-pdf/Dockerfile
+++ b/rust_setup/crates/tagomi-pdf/Dockerfile
@@ -1,0 +1,37 @@
+# Build stage
+FROM rust:1.91 AS builder
+
+WORKDIR /app
+
+# Copy manifests
+COPY Cargo.toml Cargo.lock ./
+
+# Copy source code
+COPY src ./src
+COPY assets ./assets
+
+# Build the application in release mode
+RUN cargo build --release
+
+# Runtime stage
+FROM debian:bookworm-slim
+
+# Install runtime dependencies
+RUN apt-get update && \
+    apt-get install -y ca-certificates libssl3 && \
+    rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+# Copy the binary from builder
+COPY --from=builder /app/target/release/tagomi-pdf /usr/local/bin/tagomi-pdf
+
+# Copy assets
+COPY --from=builder /app/assets ./assets
+
+# Expose default port
+EXPOSE 8085
+
+# Run the application
+CMD ["tagomi-pdf"]
+

--- a/rust_setup/crates/tagomi-pdf/docker-compose.README.md
+++ b/rust_setup/crates/tagomi-pdf/docker-compose.README.md
@@ -1,0 +1,100 @@
+# Docker Compose Setup
+
+This docker-compose configuration runs the Tagomi PDF application with HTTPS enabled and custom fonts.
+
+## Prerequisites
+
+Before running docker-compose, you need to set up:
+
+### 1. TLS Certificates
+
+Create a `certs` directory and add your SSL certificates:
+
+```bash
+mkdir -p certs
+```
+
+**For development (self-signed certificates):**
+```bash
+openssl req -x509 -newkey rsa:4096 -keyout certs/key.pem -out certs/cert.pem -days 365 -nodes -subj "/CN=localhost"
+```
+
+**For production:**
+Place your CA-signed certificates in the `certs` directory:
+- `certs/cert.pem` - Your SSL certificate
+- `certs/key.pem` - Your private key
+
+### 2. Custom Fonts (Optional)
+
+Create an `assets/fonts` directory and add your custom font files (.ttf, .otf):
+
+```bash
+mkdir -p assets/fonts
+# Copy your font files to assets/fonts/
+cp /path/to/your/fonts/*.ttf assets/fonts/
+```
+
+If you don't have custom fonts, the application will use system fonts.
+
+## Usage
+
+### Start the service:
+```bash
+docker compose up -d
+```
+
+### View logs:
+```bash
+docker compose logs -f
+```
+
+### Stop the service:
+```bash
+docker compose down
+```
+
+### Rebuild after code changes:
+```bash
+docker compose up -d --build
+```
+
+## Testing
+
+Once running, test the service:
+
+```bash
+# Health check (with self-signed cert, use -k flag)
+curl -k https://localhost:8085/health
+
+# Should return: {"data":"Tagomi PDF - UP","success":true,"error":null}
+```
+
+## Configuration
+
+Edit the environment variables in `docker-compose.yml` to customize:
+
+- **HTTPS_ENABLED**: Set to `false` to disable HTTPS
+- **PORT**: Change the application port
+- **FONTS_PATH**: Path to custom fonts inside the container
+- **USE_SYSTEM_FONTS**: Set to `false` to use only custom fonts
+- **TLS_CERT_PATH**: Path to TLS certificate
+- **TLS_KEY_PATH**: Path to TLS private key
+
+## Directory Structure
+
+```
+tagomi-pdf/
+├── docker-compose.yml
+├── Dockerfile
+├── Cargo.toml
+├── src/
+├── assets/
+│   └── fonts/          # Custom fonts directory
+│       ├── font1.ttf
+│       └── font2.otf
+└── certs/              # TLS certificates directory
+    ├── cert.pem
+    └── key.pem
+```
+
+

--- a/rust_setup/crates/tagomi-pdf/docker-compose.yml
+++ b/rust_setup/crates/tagomi-pdf/docker-compose.yml
@@ -22,11 +22,4 @@ services:
       
       # Mount custom fonts directory
       - ./assets/fonts:/app/assets/fonts:ro
-    restart: unless-stopped
-    healthcheck:
-      test: ["CMD", "curl", "-k", "-f", "https://localhost:8085/health"]
-      interval: 30s
-      timeout: 10s
-      retries: 3
-      start_period: 10s
-
+    restart: always

--- a/rust_setup/crates/tagomi-pdf/docker-compose.yml
+++ b/rust_setup/crates/tagomi-pdf/docker-compose.yml
@@ -1,0 +1,32 @@
+services:
+  tagomi-pdf:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: tagomi-pdf
+    ports:
+      - "8085:8085"
+    environment:
+      # HTTPS Configuration
+      - HTTPS_ENABLED=true
+      - PORT=8085
+      - TLS_CERT_PATH=/etc/tls/cert.pem
+      - TLS_KEY_PATH=/etc/tls/key.pem
+      
+      # Font Configuration
+      - FONTS_PATH=/app/assets/fonts
+      - USE_SYSTEM_FONTS=true
+    volumes:
+      # Mount TLS certificates
+      - ./certs:/etc/tls:ro
+      
+      # Mount custom fonts directory
+      - ./assets/fonts:/app/assets/fonts:ro
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "curl", "-k", "-f", "https://localhost:8085/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 10s
+

--- a/rust_setup/crates/tagomi-pdf/src/config.rs
+++ b/rust_setup/crates/tagomi-pdf/src/config.rs
@@ -1,0 +1,47 @@
+use std::env;
+use std::path::PathBuf;
+use std::str::FromStr;
+
+/// Server configuration loaded from environment variables
+#[derive(Debug, Clone)]
+pub struct Config {
+    /// Enable HTTPS mode (env: HTTPS_ENABLED, default: false)
+    pub https: bool,
+    /// Port to listen on (env: PORT, default: 8085)
+    pub port: u16,
+    /// Path to TLS certificate file (env: TLS_CERT_PATH, default: /etc/tls/cert.pem)
+    pub cert: PathBuf,
+    /// Path to TLS private key file (env: TLS_KEY_PATH, default: /etc/tls/key.pem)
+    pub key: PathBuf,
+    /// Path to custom fonts directory (env: FONTS_PATH, default: ./assets/fonts)
+    pub fonts_path: PathBuf,
+    /// Include system fonts in addition to custom fonts (env: USE_SYSTEM_FONTS, default: true)
+    pub use_system_fonts: bool,
+}
+
+fn env_or_default<T: FromStr>(key: &str, default: T) -> T {
+    env::var(key)
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(default)
+}
+
+fn env_path(key: &str, default: &str) -> PathBuf {
+    env::var(key)
+        .unwrap_or_else(|_| default.to_string())
+        .into()
+}
+
+impl Config {
+    pub fn from_env() -> Self {
+        let https = env_or_default("HTTPS_ENABLED", false);
+        let port = env_or_default("PORT", 8085);
+        let cert = env_path("TLS_CERT_PATH", "/etc/tls/cert.pem");
+        let key = env_path("TLS_KEY_PATH", "/etc/tls/key.pem");
+        let fonts_path = env_path("FONTS_PATH", "./assets/fonts");
+        let use_system_fonts = env_or_default("USE_SYSTEM_FONTS", true);
+
+        Self { https, port, cert, key, fonts_path, use_system_fonts }
+    }
+}
+

--- a/rust_setup/crates/tagomi-pdf/src/main.rs
+++ b/rust_setup/crates/tagomi-pdf/src/main.rs
@@ -5,19 +5,25 @@ use axum::{
     routing::{get, post},
     Router,
 };
-use tower_http::cors::{CorsLayer};
-use tracing::{info};
+use axum_server::tls_openssl::OpenSSLConfig;
+use tower_http::cors::CorsLayer;
+use tracing::info;
 use anyhow::Result;
+use std::net::SocketAddr;
 
-
+mod config;
 mod rest_api;
 mod pdf_compiler;
 
+use config::Config;
+
 use crate::rest_api::{TagomiPdfClient, TagomiPdfClientImpl, AnyResponse, PdfRequest};
 
-
 lazy_static! {
-    static ref TAGOMI_CLIENT: TagomiPdfClientImpl = TagomiPdfClientImpl::new();
+    static ref CONFIG: Config = Config::from_env();
+    static ref TAGOMI_CLIENT: TagomiPdfClientImpl = TagomiPdfClientImpl::new(
+        CONFIG.clone()
+    );
 }
 
 #[tokio::main]
@@ -27,16 +33,30 @@ async fn main() {
         .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
         .init();
 
+    let config = &*CONFIG;
+    info!("Configuration: {:?}", config);
+
     let app = Router::new()
         .route("/", get(health_check))
         .route("/health", get(health_check))
         .route("/compile", post(compile_pdf))
         .layer(CorsLayer::permissive());
 
-    let listener = tokio::net::TcpListener::bind("0.0.0.0:8085").await.unwrap();
-    info!("Server running on http://0.0.0.0:8085");
-    
-    axum::serve(listener, app).await.unwrap();
+    let addr = SocketAddr::from(([0, 0, 0, 0], config.port));
+
+    if config.https {
+        let tls_config = OpenSSLConfig::from_pem_file(&config.cert, &config.key).unwrap();
+        
+        info!("Server running on https://{}", addr);
+        axum_server::bind_openssl(addr, tls_config)
+            .serve(app.into_make_service())
+            .await
+            .unwrap();
+    } else {
+        let listener = tokio::net::TcpListener::bind(addr).await.unwrap();
+        info!("Server running on http://{}", addr);
+        axum::serve(listener, app).await.unwrap();
+    }
 }
 
 async fn health_check() -> Json<AnyResponse<String>> {

--- a/rust_setup/crates/tagomi-pdf/src/pdf_compiler/pdf_compiler.rs
+++ b/rust_setup/crates/tagomi-pdf/src/pdf_compiler/pdf_compiler.rs
@@ -3,6 +3,7 @@ use chrono::{Datelike, Utc};
 use tracing::debug;
 use typst::foundations::Datetime;
 use std::collections::HashMap;
+use std::path::PathBuf;
 use std::time::Instant;
 
 use base64::{ Engine, engine::general_purpose };
@@ -23,7 +24,9 @@ pub struct PdfCompilerImpl {
     // leaks - explicit memory leak handling
     leaks: Vec<Box<str>>,
     now: Datetime,
-    start_time: Instant
+    start_time: Instant,
+    fonts_path: PathBuf,
+    use_system_fonts: bool,
 }
 
 impl PdfCompilerImpl {
@@ -35,7 +38,9 @@ impl PdfCompilerImpl {
             modules: Vec::new(),
             leaks: Vec::new(),
             now: Datetime::from_ymd(now.year(), now.month() as u8, now.day() as u8).unwrap(),
-            start_time: Instant::now()
+            start_time: Instant::now(),
+            fonts_path: PathBuf::from("./assets/fonts"),
+            use_system_fonts: true,
         }
     }
 }
@@ -76,6 +81,11 @@ impl PdfCompiler for PdfCompilerImpl {
         self.now = today;
         self
     }
+    fn fonts_config(mut self, fonts_path: PathBuf, use_system_fonts: bool) -> Self {
+        self.fonts_path = fonts_path;
+        self.use_system_fonts = use_system_fonts;
+        self
+    }
     fn compile(mut self) -> Result<super::Pdf, super::PdfCompilerError> {
         // to the basic data validation
         let main_template = self.main_template_id.as_ref().ok_or_else(|| {
@@ -95,12 +105,24 @@ impl PdfCompiler for PdfCompilerImpl {
 
 
         let library = map_to_lib(&self.modules, &mut self.leaks);
-        //let fonts = Fonts::searcher()
-        //    .include_system_fonts(false)
-        //    .search_with(["./assets/fonts/"]);
-        let fonts = Fonts::searcher().include_system_fonts(true).search();
+        
+        // Load fonts based on configuration
+        let fonts = if self.use_system_fonts {
+            // Custom fonts + system fonts
+            debug!("Loading fonts from {} and system fonts", self.fonts_path.display());
+            Fonts::searcher()
+                .include_system_fonts(true)
+                .search_with([self.fonts_path.as_path()])
+        } else {
+            // Custom fonts only
+            debug!("Loading fonts from {} only", self.fonts_path.display());
+            Fonts::searcher()
+                .include_system_fonts(false)
+                .search_with([self.fonts_path.as_path()])
+        };
 
         // Debug loaded fonts
+        debug!("Total fonts loaded: {}", fonts.fonts.len());
         for (i, font) in fonts.fonts.iter().enumerate() {
             match font.path() {
                 Some(p) => debug!("Font {}: {}", i, p.display()),

--- a/rust_setup/crates/tagomi-pdf/src/pdf_compiler/types.rs
+++ b/rust_setup/crates/tagomi-pdf/src/pdf_compiler/types.rs
@@ -1,5 +1,6 @@
 use thiserror::Error;
 use std::result::Result;
+use std::path::PathBuf;
 
 use typst::{diag::{FileError, HintedString, SourceDiagnostic }, foundations::Datetime};
 use typst::{foundations::{ Dict }};
@@ -45,6 +46,7 @@ pub trait PdfCompiler {
     fn add_template<T: Into<PdfTemplate>>(self, template: T) -> Self;
     fn add_templates<T: Into<PdfTemplate>>(self, template: Vec<T>) -> Self;
     fn add_modules<T: Into<PdfDataModule>>(self, data: Vec<T>) -> Self;
+    fn fonts_config(self, fonts_path: PathBuf, use_system_fonts: bool) -> Self;
     fn compile(self) -> Result<Pdf, PdfCompilerError>;
 }
 

--- a/rust_setup/crates/tagomi-pdf/src/rest_api/rest_impl.rs
+++ b/rust_setup/crates/tagomi-pdf/src/rest_api/rest_impl.rs
@@ -1,13 +1,17 @@
 use chrono::{Datelike, Timelike};
 use crate::rest_api::{ AnyResponse, PdfDocument, PdfRequest, TagomiPdfClient };
 use crate::pdf_compiler::{ PdfCompiler, PdfCompilerImpl };
+use crate::config::Config;
 
-pub struct TagomiPdfClientImpl;
+pub struct TagomiPdfClientImpl {
+    config: Config,
+}
 
 
 impl TagomiPdfClientImpl {
-    pub fn new() -> Self {
+    pub fn new(config: Config) -> Self {
         Self {
+            config,
         }
     }
 }
@@ -59,6 +63,7 @@ impl TagomiPdfClient for TagomiPdfClientImpl {
             .main_template_id(payload.main_template_id)
             .add_templates(payload.templates)
             .add_modules(payload.data_modules)
+            .fonts_config(self.config.fonts_path.clone(), self.config.use_system_fonts)
             .compile();
 
         match result {


### PR DESCRIPTION
- added fonts and https config to the rust app through env variables
- created a Dockerfile 
- added a `docker-compose.yml` file that demonstrates using env configs to start the tagomi-pdf container
- added tagomi-pdf service to `eveli-local-docker/docker-compose.yaml` so that it can be started for local development
- set up a github release workflow for building and releasing Docker image to registry (in the same way it works for feedback analyzer)