### PR TITLE
#692 Template has pre filled input working, both before and after ope…

### DIFF
--- a/ts_setup/modules/tagomi-routes/tagomi-debug/DebugForm.tsx
+++ b/ts_setup/modules/tagomi-routes/tagomi-debug/DebugForm.tsx
@@ -1,59 +1,38 @@
 import React from 'react'
 import { Grid2 } from '@mui/material';
 
-import { HdesApi, WrenchComposerApi as Composer } from '@dxs-ts/wrench-api';
+import { HdesApi } from '@dxs-ts/wrench-api';
 import { InputFORMField } from './InputFORMField';
+import { useGetFlowInput } from './useGetFlowInput';
 
-
-export interface DebugFormProps {  
+export interface DebugFormProps {
   selected: HdesApi.EntityId;
   onChange: (json: object) => void;
 }
 
 export const DebugForm: React.FC<DebugFormProps> = ({ selected, onChange }) => {
-  const { decisions, flows, services } = Composer.useSite();
-  const [json, setJson] = React.useState<object>({});
-
-  const asset: HdesApi.Entity<HdesApi.AstBody> | undefined = React.useMemo(() => {
-    if (flows[selected]) {
-      return flows[selected];
-    }
-    return Object.values(flows).find(flow => flow.ast?.name === selected);
-  }, [selected, flows, services, decisions]);
-
-  const elements = asset?.ast ? asset.ast.headers.acceptDefs : [];
+  const { elements, input, setInput } = useGetFlowInput(selected);
 
   React.useEffect(() => {
-    const initialJson: Record<string, any> = {};
-    elements.forEach((typeDef) => {
-      if (typeDef.values) {
-        initialJson[typeDef.name] = typeDef.values;
-      }
-    });
-    
-    if (Object.keys(initialJson).length > 0) {
-      setJson(initialJson);
-      onChange(initialJson);
-    }
-  }, [elements, onChange]);
+    onChange(input);
+  }, [input, onChange]);
 
   const handleChange = (newValue: string, typeDef: HdesApi.TypeDef) => {
     const newObject: Record<string, any> = {};
     newObject[typeDef.name] = newValue;
-    const nextJson: object = Object.assign({}, json, newObject);
-    setJson(nextJson);
-    onChange(nextJson);
+    const nextJson = Object.assign({}, input, newObject);
+    setInput(nextJson);
   }
 
   return (
     <Grid2 container spacing={2}>
       {elements.map((typeDef, index) => (
         <Grid2 size={{ xs: 4 }} key={index}>
-          <InputFORMField typeDef={typeDef} value={getValueFromJson(typeDef, json)} onChange={handleChange} />
+          <InputFORMField typeDef={typeDef} value={getValueFromJson(typeDef, input)} onChange={handleChange} />
         </Grid2>)
       )}
     </Grid2>
- );
+  );
 }
 
 const getValueFromJson = (parameter: HdesApi.TypeDef, json: Record<string, any>) => {

--- a/ts_setup/modules/tagomi-routes/tagomi-debug/DebugForm.tsx
+++ b/ts_setup/modules/tagomi-routes/tagomi-debug/DebugForm.tsx
@@ -21,6 +21,21 @@ export const DebugForm: React.FC<DebugFormProps> = ({ selected, onChange }) => {
     return Object.values(flows).find(flow => flow.ast?.name === selected);
   }, [selected, flows, services, decisions]);
 
+  const elements = asset?.ast ? asset.ast.headers.acceptDefs : [];
+
+  React.useEffect(() => {
+    const initialJson: Record<string, any> = {};
+    elements.forEach((typeDef) => {
+      if (typeDef.values) {
+        initialJson[typeDef.name] = typeDef.values;
+      }
+    });
+    
+    if (Object.keys(initialJson).length > 0) {
+      setJson(initialJson);
+      onChange(initialJson);
+    }
+  }, [elements, onChange]);
 
   const handleChange = (newValue: string, typeDef: HdesApi.TypeDef) => {
     const newObject: Record<string, any> = {};
@@ -29,7 +44,6 @@ export const DebugForm: React.FC<DebugFormProps> = ({ selected, onChange }) => {
     setJson(nextJson);
     onChange(nextJson);
   }
-  const elements = asset?.ast ? asset.ast.headers.acceptDefs : [];
 
   return (
     <Grid2 container spacing={2}>

--- a/ts_setup/modules/tagomi-routes/tagomi-debug/DebugForm.tsx
+++ b/ts_setup/modules/tagomi-routes/tagomi-debug/DebugForm.tsx
@@ -3,7 +3,7 @@ import { Grid2 } from '@mui/material';
 
 import { HdesApi } from '@dxs-ts/wrench-api';
 import { InputFORMField } from './InputFORMField';
-import { useGetFlowInput } from './useGetFlowInput';
+import { useFlowInput } from './useFlowInput';
 
 export interface DebugFormProps {
   selected: HdesApi.EntityId;
@@ -11,7 +11,7 @@ export interface DebugFormProps {
 }
 
 export const DebugForm: React.FC<DebugFormProps> = ({ selected, onChange }) => {
-  const { elements, input, setInput } = useGetFlowInput(selected);
+  const { elements, input, setInput } = useFlowInput(selected);
 
   React.useEffect(() => {
     onChange(input);

--- a/ts_setup/modules/tagomi-routes/tagomi-debug/index.ts
+++ b/ts_setup/modules/tagomi-routes/tagomi-debug/index.ts
@@ -1,4 +1,4 @@
 export * from './DebugLocale'
 export * from './DebugPdfViewer'
 export * from './DebugForm'
-export * from './useGetFlowInput'
+export * from './useFlowInput'

--- a/ts_setup/modules/tagomi-routes/tagomi-debug/index.ts
+++ b/ts_setup/modules/tagomi-routes/tagomi-debug/index.ts
@@ -1,3 +1,4 @@
 export * from './DebugLocale'
 export * from './DebugPdfViewer'
 export * from './DebugForm'
+export * from './useGetFlowInput'

--- a/ts_setup/modules/tagomi-routes/tagomi-debug/useFlowInput.ts
+++ b/ts_setup/modules/tagomi-routes/tagomi-debug/useFlowInput.ts
@@ -1,10 +1,10 @@
 import React from 'react';
 import { HdesApi, WrenchComposerApi as Composer } from '@dxs-ts/wrench-api';
 
-export function useGetFlowInput(orchestratorName: HdesApi.EntityId) {
+export function useFlowInput(orchestratorName: HdesApi.EntityId) {
   const { flows } = Composer.useSite();
   const [input, setInput] = React.useState<Record<string, any>>({});
-
+  
   const asset: HdesApi.Entity<HdesApi.AstBody> | undefined =
     React.useMemo(() => {
       if (flows[orchestratorName]) {

--- a/ts_setup/modules/tagomi-routes/tagomi-debug/useGetFlowInput.ts
+++ b/ts_setup/modules/tagomi-routes/tagomi-debug/useGetFlowInput.ts
@@ -1,0 +1,41 @@
+import React from 'react';
+import { HdesApi, WrenchComposerApi as Composer } from '@dxs-ts/wrench-api';
+
+export function useGetFlowInput(orchestratorName: HdesApi.EntityId) {
+  const { flows } = Composer.useSite();
+  const [input, setInput] = React.useState<Record<string, any>>({});
+
+  const asset: HdesApi.Entity<HdesApi.AstBody> | undefined =
+    React.useMemo(() => {
+      if (flows[orchestratorName]) {
+        return flows[orchestratorName];
+      }
+      return Object.values(flows).find(
+        (flow) => flow.ast?.name === orchestratorName
+      );
+    }, [orchestratorName, flows]);
+
+  const elements = React.useMemo(() => {
+    return asset?.ast?.headers?.acceptDefs ?? [];
+  }, [asset]);
+
+  React.useEffect(() => {
+    const initialJson: Record<string, any> = {};
+    elements.forEach((def) => {
+      if (def.values) {
+        initialJson[def.name] = def.values;
+      }
+    });
+
+    if (Object.keys(initialJson).length > 0) {
+      setInput(initialJson);
+    }
+  }, [elements]);
+
+  return {
+    asset,
+    elements,
+    input,
+    setInput,
+  };
+}

--- a/ts_setup/modules/tagomi-routes/tagomi-template/TemplateEditor.tsx
+++ b/ts_setup/modules/tagomi-routes/tagomi-template/TemplateEditor.tsx
@@ -6,8 +6,7 @@ import { Box, Button, Dialog, DialogActions, DialogContent, DialogTitle, Typogra
 import { useIntl } from 'react-intl';
 
 import { TagomiComposerApi } from '@dxs-ts/tagomi-api';
-import { HdesApi, WrenchComposerApi as Composer } from '@dxs-ts/wrench-api';
-import { DebugPdfViewer, DebugForm } from '../tagomi-debug';
+import { DebugPdfViewer, DebugForm, useGetFlowInput } from '../tagomi-debug';
 
 
 interface Message {
@@ -21,8 +20,6 @@ export const TemplateEditor: React.FC<{ serviceId: string, templateId: string }>
   const messages: Message[] = [];
   const monaco: typeof monaco_editor | null = useMonaco();
   const composer = TagomiComposerApi.useComposer();
-  const { flows } = Composer.useSite();
-  const [input, setInput] = React.useState<object>({});
   const [inputOpen, setInputOpen] = React.useState<boolean>(false);
   const [base64, setBase64] = React.useState<string>();
 
@@ -30,29 +27,7 @@ export const TemplateEditor: React.FC<{ serviceId: string, templateId: string }>
   const service = composer.site.services[serviceId];
   const localeLabel = service.labels.find(l => l.locale === template.localeId)?.labelValue ?? '';
   const [src, setSrc] = React.useState(template.content);
-
-  React.useEffect(() => {
-    const orchestratorName = service.orchestratorName;
-    
-    const asset: HdesApi.Entity<HdesApi.AstBody> | undefined = flows[orchestratorName] 
-      ? flows[orchestratorName]
-      : Object.values(flows).find(flow => flow.ast?.name === orchestratorName);
-    
-    if (!asset?.ast?.headers?.acceptDefs) {
-      return;
-    }
-
-    const initialJson: Record<string, any> = {};
-    asset.ast.headers.acceptDefs.forEach((typeDef) => {
-      if (typeDef.values) {
-        initialJson[typeDef.name] = typeDef.values;
-      }
-    });
-    
-    if (Object.keys(initialJson).length > 0) {
-      setInput(initialJson);
-    }
-  }, [service.orchestratorName, flows]);
+  const { input, setInput } = useGetFlowInput(service.orchestratorName);
 
   async function handleCompile() {
     const pdf = await composer.backend.compileTemplate(serviceId, template.localeId, input);

--- a/ts_setup/modules/tagomi-routes/tagomi-template/TemplateEditor.tsx
+++ b/ts_setup/modules/tagomi-routes/tagomi-template/TemplateEditor.tsx
@@ -6,7 +6,7 @@ import { Box, Button, Dialog, DialogActions, DialogContent, DialogTitle, Typogra
 import { useIntl } from 'react-intl';
 
 import { TagomiComposerApi } from '@dxs-ts/tagomi-api';
-import { DebugPdfViewer, DebugForm, useGetFlowInput } from '../tagomi-debug';
+import { DebugPdfViewer, DebugForm, useFlowInput } from '../tagomi-debug';
 
 
 interface Message {
@@ -27,7 +27,7 @@ export const TemplateEditor: React.FC<{ serviceId: string, templateId: string }>
   const service = composer.site.services[serviceId];
   const localeLabel = service.labels.find(l => l.locale === template.localeId)?.labelValue ?? '';
   const [src, setSrc] = React.useState(template.content);
-  const { input, setInput } = useGetFlowInput(service.orchestratorName);
+  const { input, setInput } = useFlowInput(service.orchestratorName);
 
   async function handleCompile() {
     const pdf = await composer.backend.compileTemplate(serviceId, template.localeId, input);

--- a/ts_setup/modules/tagomi-routes/tagomi-template/TemplateEditor.tsx
+++ b/ts_setup/modules/tagomi-routes/tagomi-template/TemplateEditor.tsx
@@ -6,6 +6,7 @@ import { Box, Button, Dialog, DialogActions, DialogContent, DialogTitle, Typogra
 import { useIntl } from 'react-intl';
 
 import { TagomiComposerApi } from '@dxs-ts/tagomi-api';
+import { HdesApi, WrenchComposerApi as Composer } from '@dxs-ts/wrench-api';
 import { DebugPdfViewer, DebugForm } from '../tagomi-debug';
 
 
@@ -20,6 +21,7 @@ export const TemplateEditor: React.FC<{ serviceId: string, templateId: string }>
   const messages: Message[] = [];
   const monaco: typeof monaco_editor | null = useMonaco();
   const composer = TagomiComposerApi.useComposer();
+  const { flows } = Composer.useSite();
   const [input, setInput] = React.useState<object>({});
   const [inputOpen, setInputOpen] = React.useState<boolean>(false);
   const [base64, setBase64] = React.useState<string>();
@@ -28,6 +30,29 @@ export const TemplateEditor: React.FC<{ serviceId: string, templateId: string }>
   const service = composer.site.services[serviceId];
   const localeLabel = service.labels.find(l => l.locale === template.localeId)?.labelValue ?? '';
   const [src, setSrc] = React.useState(template.content);
+
+  React.useEffect(() => {
+    const orchestratorName = service.orchestratorName;
+    
+    const asset: HdesApi.Entity<HdesApi.AstBody> | undefined = flows[orchestratorName] 
+      ? flows[orchestratorName]
+      : Object.values(flows).find(flow => flow.ast?.name === orchestratorName);
+    
+    if (!asset?.ast?.headers?.acceptDefs) {
+      return;
+    }
+
+    const initialJson: Record<string, any> = {};
+    asset.ast.headers.acceptDefs.forEach((typeDef) => {
+      if (typeDef.values) {
+        initialJson[typeDef.name] = typeDef.values;
+      }
+    });
+    
+    if (Object.keys(initialJson).length > 0) {
+      setInput(initialJson);
+    }
+  }, [service.orchestratorName, flows]);
 
   async function handleCompile() {
     const pdf = await composer.backend.compileTemplate(serviceId, template.localeId, input);


### PR DESCRIPTION

https://github.com/user-attachments/assets/4e4ae91f-2e4b-40ce-9c1e-7eef1cc5cdd2

Made it so that when the user comes to the PDF editor, the debug values specified in a service flow are already available and user can click on the "Compile" button and it will show the PDF preview with the debug values. 
Also, the user can open the "Fill Input" button to see the values and click accept without needing to edit the fields, click "Compile", and it will compile the pdf with the pre filled values.